### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @safe-research/dev


### PR DESCRIPTION
Adds a new CODEOWNERS file so the dev team is automatically summoned to review PRs in `harbour` repo.

@rmeissner - you might need to add the `dev` team to the harbour repository with WRITE access for the CODEOWNERS file to work.