### PR TITLE
Add Benchmarking Support

### DIFF
--- a/contracts/test/SafeInternationalHarbour.4337.Bench.spec.ts
+++ b/contracts/test/SafeInternationalHarbour.4337.Bench.spec.ts
@@ -1,101 +1,27 @@
-import { AddressOne } from "@safe-global/safe-contracts";
-import { type Signer, type TransactionReceipt, Wallet } from "ethers";
 import { ethers } from "hardhat";
-import { EntryPoint__factory, SafeInternationalHarbour__factory, TestPaymaster__factory } from "../typechain-types";
-import { build4337Config, buildSafeTx, buildSignedUserOp } from "./utils/erc4337";
+import { describeBench } from "./utils/bench";
+import { build4337Config, buildSignedUserOp } from "./utils/erc4337";
 
-const logGas = (label: string, tx: TransactionReceipt): void => {
-	if (!tx || !tx.gasUsed) {
-		console.warn(`⚠️  ${label.padEnd(12)} - Missing gasUsed info.`);
-		return;
-	}
-
-	const formattedLabel = label.padEnd(12);
-	const gasUsed = tx.gasUsed.toString(); // In case it's a BigNumber or similar
-
-	console.log(`⛽ ${formattedLabel}: ${gasUsed}`);
-};
-
-describe("SafeInternationalHarbour 4337 [@bench]", () => {
-	async function deployFixture() {
-		const [deployer, alice] = await ethers.getSigners();
-		const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+describeBench(
+	"SafeInternationalHarbour.4337",
+	async () => {
 		// TODO: use test token to include fee payment overhead
-		const EntryPointFactory = new EntryPoint__factory(deployer as unknown as Signer);
+		const EntryPointFactory = await ethers.getContractFactory("EntryPoint");
 		const entryPoint = await EntryPointFactory.deploy();
-		const TestPaymasterFactory = new TestPaymaster__factory(deployer as unknown as Signer);
+
+		const TestPaymasterFactory = await ethers.getContractFactory("TestPaymaster");
 		const paymaster = await TestPaymasterFactory.deploy();
 		const paymasterAddress = await paymaster.getAddress();
-		const HarbourFactory = new SafeInternationalHarbour__factory(deployer as unknown as Signer);
+		const paymasterAndData = ethers.solidityPacked(["address", "uint128", "uint128"], [paymasterAddress, 500_000, 0]);
+
+		const HarbourFactory = await ethers.getContractFactory("SafeInternationalHarbour");
 		const erc4337config = build4337Config({ entryPoint: await entryPoint.getAddress() });
 		const harbour = await HarbourFactory.deploy(erc4337config);
 
-		const paymasterAndData = ethers.solidityPacked(["address", "uint128", "uint128"], [paymasterAddress, 500_000, 0]);
-
-		const safeAddress = await alice.getAddress();
-		return { entryPoint, deployer, alice, harbour, chainId, safeAddress, paymasterAndData };
-	}
-
-	it("Enqueuing a transaction with empty transaction data (native transfer)", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, paymasterAndData } = await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const safeTx = buildSafeTx({ to: deployer.address });
-		const { userOp } = await buildSignedUserOp(harbour, signerWallet, chainId, safeAddress, safeTx, paymasterAndData);
-		const tx = await entryPoint.handleOps([userOp], AddressOne);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("native_transfer_0b", receipt);
-	});
-
-	it("Enqueuing a transaction with ERC20 transfer data (68 bytes)", async () => {
-		const { entryPoint, harbour, chainId, safeAddress, paymasterAndData } = await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const recipient = Wallet.createRandom().address;
-		const amount = 1n * 10n ** 18n;
-		const erc20Iface = new ethers.Interface(["function transfer(address to,uint256 amount)"]);
-		const data = erc20Iface.encodeFunctionData("transfer", [recipient, amount]);
-		const safeTx = buildSafeTx({ to: recipient, data });
-		const { userOp } = await buildSignedUserOp(harbour, signerWallet, chainId, safeAddress, safeTx, paymasterAndData);
-		const tx = await entryPoint.handleOps([userOp], AddressOne);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("erc20_transfer_68b", receipt);
-	});
-
-	it("Enqueuing a transaction with large transaction data", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, paymasterAndData } = await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const data = `0x${"ff".repeat(1024)}`;
-		const safeTx = buildSafeTx({ to: deployer.address, data });
-		const { userOp } = await buildSignedUserOp(harbour, signerWallet, chainId, safeAddress, safeTx, paymasterAndData);
-		const tx = await entryPoint.handleOps([userOp], AddressOne);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("large_tx_data_1024b", receipt);
-	});
-
-	it("Appending a signature to an existing transaction", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, paymasterAndData } = await deployFixture();
-		const signerWallet1 = Wallet.createRandom();
-		const safeTx = buildSafeTx({ to: deployer.address });
-		const { userOp: userOp1 } = await buildSignedUserOp(
-			harbour,
-			signerWallet1,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-		);
-		await entryPoint.handleOps([userOp1], AddressOne);
-
-		const signerWallet2 = Wallet.createRandom();
-		const { userOp: userOp2 } = await buildSignedUserOp(
-			harbour,
-			signerWallet2,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-		);
-		const tx = await entryPoint.handleOps([userOp2], AddressOne);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("append_sig_same_tx", receipt);
-	});
-});
+		return { entryPoint, harbour, paymasterAndData };
+	},
+	async ({ deployer, signer, entryPoint, harbour, chainId, safe, safeTx, paymasterAndData }) => {
+		const { userOp } = await buildSignedUserOp(harbour, signer, chainId, safe, safeTx, paymasterAndData);
+		return await entryPoint.handleOps([userOp], deployer.address);
+	},
+);

--- a/contracts/test/SafeInternationalHarbour.Bench.spec.ts
+++ b/contracts/test/SafeInternationalHarbour.Bench.spec.ts
@@ -1,54 +1,21 @@
-import type { Signer, TransactionReceipt } from "ethers";
 import { ethers } from "hardhat";
-import { SafeInternationalHarbour__factory } from "../typechain-types";
+import { describeBench } from "./utils/bench";
 import { build4337Config } from "./utils/erc4337";
-import { EIP712_SAFE_TX_TYPE, type SafeTransaction } from "./utils/safeTx";
+import { signSafeTransaction } from "./utils/safeTx";
 
-const logGas = (label: string, tx: TransactionReceipt): void => {
-	if (!tx || !tx.gasUsed) {
-		console.warn(`⚠️  ${label.padEnd(12)} - Missing gasUsed info.`);
-		return;
-	}
+describeBench(
+	"SafeSecretHarbour",
+	async ([entryPoint]) => {
+		const Factory = await ethers.getContractFactory("SafeInternationalHarbour");
+		const erc4337config = build4337Config({ entryPoint: entryPoint.address });
+		const harbour = await Factory.deploy(erc4337config);
 
-	const formattedLabel = label.padEnd(12);
-	const gasUsed = tx.gasUsed.toString(); // In case it's a BigNumber or similar
-
-	console.log(`⛽ ${formattedLabel}: ${gasUsed}`);
-};
-
-describe("SafeInternationalHarbour [@bench]", () => {
-	async function deployFixture() {
-		const [deployer, alice] = await ethers.getSigners();
-		const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
-		const Factory = new SafeInternationalHarbour__factory(deployer as unknown as Signer);
-		const harbour = await Factory.deploy(build4337Config());
-
-		const safeAddress = await alice.getAddress();
-		return { deployer, alice, harbour, chainId, safeAddress };
-	}
-
-	it("Enqueuing a transaction with empty transaction data (native transfer)", async () => {
-		const { deployer, harbour, chainId, safeAddress } = await deployFixture();
-		const signerWallet = ethers.Wallet.createRandom();
-		const safeTx: SafeTransaction = {
-			to: deployer.address,
-			value: 0n,
-			data: "0x",
-			operation: 0,
-			safeTxGas: 0n,
-			baseGas: 0n,
-			gasPrice: 0n,
-			gasToken: ethers.ZeroAddress,
-			refundReceiver: ethers.ZeroAddress,
-			nonce: 0n,
-		};
-		const signature = await signerWallet.signTypedData(
-			{ chainId, verifyingContract: safeAddress },
-			EIP712_SAFE_TX_TYPE,
-			safeTx,
-		);
-		const tx = await harbour.enqueueTransaction(
-			safeAddress,
+		return { harbour };
+	},
+	async ({ signer, harbour, chainId, safe, safeTx }) => {
+		const signature = await signSafeTransaction(signer, safe, chainId, safeTx);
+		return await harbour.enqueueTransaction(
+			safe,
 			chainId,
 			safeTx.nonce,
 			safeTx.to,
@@ -62,150 +29,5 @@ describe("SafeInternationalHarbour [@bench]", () => {
 			safeTx.refundReceiver,
 			signature,
 		);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("native_transfer_0b", receipt);
-	});
-
-	it("Enqueuing a transaction with ERC20 transfer data (68 bytes)", async () => {
-		const { harbour, chainId, safeAddress } = await deployFixture();
-		const signerWallet = ethers.Wallet.createRandom();
-		const recipient = ethers.Wallet.createRandom().address;
-		const amount = 1n * 10n ** 18n;
-		const erc20Iface = new ethers.Interface(["function transfer(address to,uint256 amount)"]);
-		const data = erc20Iface.encodeFunctionData("transfer", [recipient, amount]);
-		const safeTx: SafeTransaction = {
-			to: recipient,
-			value: 0n,
-			data,
-			operation: 0,
-			safeTxGas: 0n,
-			baseGas: 0n,
-			gasPrice: 0n,
-			gasToken: ethers.ZeroAddress,
-			refundReceiver: ethers.ZeroAddress,
-			nonce: 0n,
-		};
-		const signature = await signerWallet.signTypedData(
-			{ chainId, verifyingContract: safeAddress },
-			EIP712_SAFE_TX_TYPE,
-			safeTx,
-		);
-		const tx = await harbour.enqueueTransaction(
-			safeAddress,
-			chainId,
-			safeTx.nonce,
-			safeTx.to,
-			safeTx.value,
-			safeTx.data,
-			safeTx.operation,
-			safeTx.safeTxGas,
-			safeTx.baseGas,
-			safeTx.gasPrice,
-			safeTx.gasToken,
-			safeTx.refundReceiver,
-			signature,
-		);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("erc20_transfer_68b", receipt);
-	});
-
-	it("Enqueuing a transaction with large transaction data", async () => {
-		const { deployer, harbour, chainId, safeAddress } = await deployFixture();
-		const signerWallet = ethers.Wallet.createRandom();
-		const data = `0x${"ff".repeat(1024)}`;
-		const safeTx: SafeTransaction = {
-			to: deployer.address,
-			value: 0n,
-			data,
-			operation: 0,
-			safeTxGas: 0n,
-			baseGas: 0n,
-			gasPrice: 0n,
-			gasToken: ethers.ZeroAddress,
-			refundReceiver: ethers.ZeroAddress,
-			nonce: 0n,
-		};
-		const signature = await signerWallet.signTypedData(
-			{ chainId, verifyingContract: safeAddress },
-			EIP712_SAFE_TX_TYPE,
-			safeTx,
-		);
-		const tx = await harbour.enqueueTransaction(
-			safeAddress,
-			chainId,
-			safeTx.nonce,
-			safeTx.to,
-			safeTx.value,
-			safeTx.data,
-			safeTx.operation,
-			safeTx.safeTxGas,
-			safeTx.baseGas,
-			safeTx.gasPrice,
-			safeTx.gasToken,
-			safeTx.refundReceiver,
-			signature,
-		);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("large_tx_data_1024b", receipt);
-	});
-
-	it("Appending a signature to an existing transaction", async () => {
-		const { deployer, harbour, chainId, safeAddress } = await deployFixture();
-		const signerWallet1 = ethers.Wallet.createRandom();
-		const safeTx: SafeTransaction = {
-			to: deployer.address,
-			value: 0n,
-			data: "0x",
-			operation: 0,
-			safeTxGas: 0n,
-			baseGas: 0n,
-			gasPrice: 0n,
-			gasToken: ethers.ZeroAddress,
-			refundReceiver: ethers.ZeroAddress,
-			nonce: 0n,
-		};
-		const signature1 = await signerWallet1.signTypedData(
-			{ chainId, verifyingContract: safeAddress },
-			EIP712_SAFE_TX_TYPE,
-			safeTx,
-		);
-		await harbour.enqueueTransaction(
-			safeAddress,
-			chainId,
-			safeTx.nonce,
-			safeTx.to,
-			safeTx.value,
-			safeTx.data,
-			safeTx.operation,
-			safeTx.safeTxGas,
-			safeTx.baseGas,
-			safeTx.gasPrice,
-			safeTx.gasToken,
-			safeTx.refundReceiver,
-			signature1,
-		);
-		const signerWallet2 = ethers.Wallet.createRandom();
-		const signature2 = await signerWallet2.signTypedData(
-			{ chainId, verifyingContract: safeAddress },
-			EIP712_SAFE_TX_TYPE,
-			safeTx,
-		);
-		const tx = await harbour.enqueueTransaction(
-			safeAddress,
-			chainId,
-			safeTx.nonce,
-			safeTx.to,
-			safeTx.value,
-			safeTx.data,
-			safeTx.operation,
-			safeTx.safeTxGas,
-			safeTx.baseGas,
-			safeTx.gasPrice,
-			safeTx.gasToken,
-			safeTx.refundReceiver,
-			signature2,
-		);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("append_sig_same_tx", receipt);
-	});
-});
+	},
+);

--- a/contracts/test/SafeInternationalHarbour.Paymaster.Bench.spec.ts
+++ b/contracts/test/SafeInternationalHarbour.Paymaster.Bench.spec.ts
@@ -1,37 +1,20 @@
-import { type Signer, type TransactionReceipt, toBigInt, Wallet } from "ethers";
 import { ethers } from "hardhat";
-import {
-	EntryPoint__factory,
-	SafeHarbourPaymaster__factory,
-	SafeInternationalHarbour__factory,
-	TestToken__factory,
-} from "../typechain-types";
-import { build4337Config, buildSafeTx, buildSignedUserOp, encodePaymasterData } from "./utils/erc4337";
+import { describeBench } from "./utils/bench";
+import { build4337Config, buildSignedUserOp, encodePaymasterData } from "./utils/erc4337";
 import { addValidatorSignature, buildQuotaConfig } from "./utils/quota";
 import { buildSlashingConfig } from "./utils/slashing";
 
-const logGas = (label: string, tx: TransactionReceipt): void => {
-	if (!tx || !tx.gasUsed) {
-		console.warn(`⚠️  ${label.padEnd(12)} - Missing gasUsed info.`);
-		return;
-	}
-
-	const formattedLabel = label.padEnd(12);
-	const gasUsed = tx.gasUsed.toString(); // In case it's a BigNumber or similar
-
-	console.log(`⛽ ${formattedLabel}: ${gasUsed}`);
-};
-
-describe("SafeInternationalHarbour Paymaster [@bench]", () => {
-	async function deployFixture() {
-		const [deployer, alice, bob, charlie] = await ethers.getSigners();
-		const validator = charlie as unknown as Signer;
-		const testTokenFactory = new TestToken__factory(deployer as unknown as Signer);
-		const testToken = await testTokenFactory.deploy();
-		const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
-		const EntryPointFactory = new EntryPoint__factory(deployer as unknown as Signer);
+describeBench(
+	"SafeInternationalHarbour.Paymaster",
+	async ([bob, validator]) => {
+		const EntryPointFactory = await ethers.getContractFactory("EntryPoint");
 		const entryPoint = await EntryPointFactory.deploy();
-		const PaymasterFactory = new SafeHarbourPaymaster__factory(deployer as unknown as Signer);
+		const { chainId: entryPointChainId } = await ethers.provider.getNetwork();
+
+		const TestTokenFactory = await ethers.getContractFactory("TestToken");
+		const testToken = await TestTokenFactory.deploy();
+
+		const PaymasterFactory = await ethers.getContractFactory("SafeHarbourPaymaster");
 		const paymaster = await PaymasterFactory.deploy(
 			bob,
 			entryPoint,
@@ -47,117 +30,33 @@ describe("SafeInternationalHarbour Paymaster [@bench]", () => {
 		await testToken.approve(paymaster, ethers.parseUnits("1", 18));
 		await paymaster.depositTokensForSigner(validator, ethers.parseUnits("1", 18));
 
-		const HarbourFactory = new SafeInternationalHarbour__factory(deployer as unknown as Signer);
-		const erc4337config = build4337Config({
-			entryPoint: await entryPoint.getAddress(),
-		});
-		const harbour = await HarbourFactory.deploy(erc4337config);
-
 		const paymasterAndData = await encodePaymasterData({ paymaster });
 		const gasFee = {
-			maxFeePerGas: toBigInt("0xb00"),
-			maxPriorityFeePerGas: toBigInt("0xf4240"),
+			maxFeePerGas: 0xb00n,
+			maxPriorityFeePerGas: 0xf4240n,
 		};
 
-		const safeAddress = await alice.getAddress();
-		return { entryPoint, deployer, alice, harbour, chainId, safeAddress, gasFee, paymasterAndData, validator };
-	}
+		const HarbourFactory = await ethers.getContractFactory("SafeInternationalHarbour");
+		const erc4337config = build4337Config({ entryPoint: await entryPoint.getAddress() });
+		const harbour = await HarbourFactory.deploy(erc4337config);
 
-	it("Enqueuing a transaction with empty transaction data (native transfer)", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, gasFee, paymasterAndData, validator } =
-			await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const safeTx = buildSafeTx({ to: deployer.address });
-		const { userOp } = await buildSignedUserOp(
-			harbour,
-			signerWallet,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-			gasFee,
-		);
-		await addValidatorSignature(chainId, entryPoint, userOp, validator);
-		const tx = await entryPoint.handleOps([userOp], deployer);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("native_transfer_0b", receipt);
-	});
-
-	it("Enqueuing a transaction with ERC20 transfer data (68 bytes)", async () => {
-		const { deployer, entryPoint, harbour, chainId, safeAddress, paymasterAndData, gasFee, validator } =
-			await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const recipient = Wallet.createRandom().address;
-		const amount = 1n * 10n ** 18n;
-		const erc20Iface = new ethers.Interface(["function transfer(address to,uint256 amount)"]);
-		const data = erc20Iface.encodeFunctionData("transfer", [recipient, amount]);
-		const safeTx = buildSafeTx({ to: recipient, data });
-		const { userOp } = await buildSignedUserOp(
-			harbour,
-			signerWallet,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-			gasFee,
-		);
-		await addValidatorSignature(chainId, entryPoint, userOp, validator);
-		const tx = await entryPoint.handleOps([userOp], deployer);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("erc20_transfer_68b", receipt);
-	});
-
-	it("Enqueuing a transaction with large transaction data", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, paymasterAndData, gasFee, validator } =
-			await deployFixture();
-		const signerWallet = Wallet.createRandom();
-		const data = `0x${"ff".repeat(1024)}`;
-		const safeTx = buildSafeTx({ to: deployer.address, data });
-		const { userOp } = await buildSignedUserOp(
-			harbour,
-			signerWallet,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-			gasFee,
-		);
-		await addValidatorSignature(chainId, entryPoint, userOp, validator);
-		const tx = await entryPoint.handleOps([userOp], deployer);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("large_tx_data_1024b", receipt);
-	});
-
-	it("Appending a signature to an existing transaction", async () => {
-		const { entryPoint, deployer, harbour, chainId, safeAddress, paymasterAndData, gasFee, validator } =
-			await deployFixture();
-		const signerWallet1 = Wallet.createRandom();
-		const safeTx = buildSafeTx({ to: deployer.address });
-		const { userOp: userOp1 } = await buildSignedUserOp(
-			harbour,
-			signerWallet1,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-			gasFee,
-		);
-		await addValidatorSignature(chainId, entryPoint, userOp1, validator);
-		await entryPoint.handleOps([userOp1], deployer);
-
-		const signerWallet2 = Wallet.createRandom();
-		const { userOp: userOp2 } = await buildSignedUserOp(
-			harbour,
-			signerWallet2,
-			chainId,
-			safeAddress,
-			safeTx,
-			paymasterAndData,
-			gasFee,
-		);
-		await addValidatorSignature(chainId, entryPoint, userOp2, validator);
-		const tx = await entryPoint.handleOps([userOp2], deployer);
-		const receipt = (await tx.wait()) as TransactionReceipt;
-		await logGas("append_sig_same_tx", receipt);
-	});
-});
+		return { entryPoint, entryPointChainId, harbour, gasFee, paymasterAndData, validator };
+	},
+	async ({
+		deployer,
+		signer,
+		entryPoint,
+		entryPointChainId,
+		harbour,
+		chainId,
+		safe,
+		safeTx,
+		paymasterAndData,
+		gasFee,
+		validator,
+	}) => {
+		const { userOp } = await buildSignedUserOp(harbour, signer, chainId, safe, safeTx, paymasterAndData, gasFee);
+		await addValidatorSignature(entryPointChainId, entryPoint, userOp, validator);
+		return await entryPoint.handleOps([userOp], deployer);
+	},
+);

--- a/contracts/test/SafeSecretHarbour.Bench.spec.ts
+++ b/contracts/test/SafeSecretHarbour.Bench.spec.ts
@@ -1,0 +1,27 @@
+import { ethers } from "hardhat";
+import { describeBench } from "./utils/bench";
+import { encryptSafeTransaction, randomX25519KeyPair } from "./utils/encryption";
+import { getSafeTransactionStructHash, signSafeTransaction } from "./utils/safeTx";
+
+describeBench(
+	"SafeSecretHarbour",
+	async () => {
+		const Factory = await ethers.getContractFactory("SafeSecretHarbour");
+		const harbour = await Factory.deploy();
+
+		const recipients = await Promise.all(
+			[...Array(3)].map(async () => {
+				const { encryptionKey } = await randomX25519KeyPair();
+				return encryptionKey;
+			}),
+		);
+
+		return { harbour, recipients };
+	},
+	async ({ signer, harbour, chainId, safe, safeTx, existing, recipients }) => {
+		const safeTxStructHash = getSafeTransactionStructHash(safeTx);
+		const signature = await signSafeTransaction(signer, safe, chainId, safeTx);
+		const encryptedSafeTx = existing ? "0x" : await encryptSafeTransaction(safeTx, recipients);
+		return await harbour.registerTransaction(chainId, safe, safeTx.nonce, safeTxStructHash, signature, encryptedSafeTx);
+	},
+);

--- a/contracts/test/utils/bench.ts
+++ b/contracts/test/utils/bench.ts
@@ -1,0 +1,87 @@
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import type { TransactionReceipt, TransactionResponse } from "ethers";
+import { ethers } from "hardhat";
+import { populateSafeTransaction, type SafeTransaction } from "./safeTx";
+
+function logGas(label: string, tx: TransactionReceipt | null): void {
+	const formattedLabel = label.padEnd(20);
+	const gasUsed = tx?.gasUsed;
+	if (gasUsed) {
+		console.log(`⛽ ${formattedLabel}: ${tx.gasUsed}`);
+	} else {
+		console.warn(`⚠️  ${formattedLabel}: missing gas info`);
+	}
+}
+
+type FixtureFunction<T> = (others: SignerWithAddress[]) => Promise<T>;
+type BenchFixture<T> = {
+	chainId: bigint;
+	safe: string;
+	deployer: SignerWithAddress;
+	signer: SignerWithAddress;
+	safeTx: SafeTransaction;
+	existing?: true;
+} & T;
+type TransactionFunction<T> = (f: BenchFixture<T>) => Promise<TransactionResponse>;
+
+const ERC20 = new ethers.Interface(["function transfer(address to, uint256 amount) returns (bool success)"]);
+
+function describeBench<T>(name: string, fixture: FixtureFunction<T>, transact: TransactionFunction<T>) {
+	describe(`${name} [@bench]`, () => {
+		async function deployFixture() {
+			const [deployer, signer, alice, ...others] = await ethers.getSigners();
+
+			const chainId = 0x5afen;
+			const safe = ethers.getAddress(`0x${"5afe".repeat(10)}`);
+
+			const inner = await fixture(others);
+			return { deployer, signer, alice, chainId, safe, inner };
+		}
+
+		function simpleBench(
+			description: string,
+			id: string,
+			build: (args: { recipient: SignerWithAddress }) => Partial<SafeTransaction>,
+		) {
+			it(description, async () => {
+				const { deployer, signer, chainId, safe, inner } = await loadFixture(deployFixture);
+
+				const safeTx = populateSafeTransaction(build({ recipient: deployer }));
+				const tx = await transact({ deployer, signer, chainId, safe, safeTx, ...inner });
+				const receipt = await tx.wait();
+				logGas(id, receipt);
+			});
+		}
+
+		simpleBench("empty transaction", "empty_0b", () => ({}));
+
+		simpleBench("native transfer", "native_transfer_0b", ({ recipient }) => ({
+			to: recipient.address,
+			value: ethers.parseEther("1.0"),
+		}));
+
+		simpleBench("ERC20 transfer (68 bytes)", "erc20_transfer_68b", ({ recipient }) => ({
+			to: recipient.address,
+			data: ERC20.encodeFunctionData("transfer", [recipient.address, ethers.parseEther("1.0")]),
+		}));
+
+		simpleBench("large transaction data", "large_tx_data_1024b", ({ recipient }) => ({
+			to: recipient.address,
+			data: `0x${"ff".repeat(1024)}`,
+		}));
+
+		it("additional signature to an existing transaction", async () => {
+			const { deployer, signer, alice, chainId, safe, inner } = await loadFixture(deployFixture);
+
+			const safeTx = populateSafeTransaction({ to: deployer.address });
+			await transact({ deployer, signer: alice, chainId, safe, safeTx, ...inner });
+			const tx = await transact({ deployer, signer, chainId, safe, safeTx, existing: true, ...inner });
+			const receipt = await tx.wait();
+			await logGas("append_sig_same_tx", receipt);
+		});
+	});
+}
+
+export type { FixtureFunction, BenchFixture, TransactionFunction };
+export { describeBench };

--- a/contracts/test/utils/erc4337.ts
+++ b/contracts/test/utils/erc4337.ts
@@ -103,7 +103,7 @@ export function buildSafeTx(params: Partial<SafeTransaction> = {}): SafeTransact
 
 export async function buildSignedUserOp(
 	harbour: SafeInternationalHarbour,
-	signerWallet: Signer,
+	signerWallet: Pick<Signer, "getAddress" | "signTypedData">,
 	chainId: bigint,
 	safeAddress: string,
 	safeTx: SafeTransaction,
@@ -226,7 +226,7 @@ export async function signUserOp(
 	chainId: bigint,
 	entryPoint: EntryPoint,
 	userOp: PackedUserOperationStruct,
-	signer: Signer,
+	signer: Pick<Signer, "signTypedData">,
 ): Promise<string> {
 	return signer.signTypedData(
 		{

--- a/contracts/test/utils/quota.ts
+++ b/contracts/test/utils/quota.ts
@@ -37,7 +37,7 @@ export async function addValidatorSignature(
 	chainId: bigint,
 	entryPoint: EntryPoint,
 	userOp: PackedUserOperationStruct,
-	validator: Signer,
+	validator: Pick<Signer, "signTypedData">,
 ) {
 	const validatorSig = Signature.from(await signUserOp(chainId, entryPoint, userOp, validator));
 	userOp.signature = validatorSig.serialized;


### PR DESCRIPTION
This PR adds benchmarks for the Safe secret harbour, which look promising :smile::

```
  SafeSecretHarbour [@bench]
⛽ empty_0b            : 88980
    ✔ empty transaction (47ms)
⛽ native_transfer_0b  : 89100
    ✔ native transfer
⛽ erc20_transfer_68b  : 90720
    ✔ ERC20 transfer (68 bytes)
⛽ large_tx_data_1024b : 113839
    ✔ large transaction data
⛽ append_sig_same_tx  : 76810
    ✔ additional signature to an existing transaction
```

I also refactored benchmarking altogether - I created a new benchmarking harness in `bench.ts`, and re-expressed the existing benchmarks using that harness. Addionally, there is a new benchmarking case to distinguish between native token transfers and empty transactions (previously, we were submitting transactions to an address with no value and mislabelling it as a native token transfer).

Some minor types were reworked to work around the fact that hardhat `SignerWithAddress`s are not compatible with ethers `Signer`s (because of 7702 stuff, which isn't supported by Hardhat at the moment) and just pick the signer functionality we need for our utility functions.