### PR TITLE
Identify Harbour Contracts by ERC-165

### DIFF
--- a/contracts/src/SafeSecretHarbour.sol
+++ b/contracts/src/SafeSecretHarbour.sol
@@ -5,7 +5,9 @@ import {
     EncryptionKeyRegistered,
     SafeTransactionRegistered
 } from "./interfaces/Events.sol";
+import {ISafeSecretHarbour} from "./interfaces/Harbour.sol";
 import {SafeTransactionRegistrationHandle} from "./interfaces/Types.sol";
+import {IERC165} from "./interfaces/ERC165.sol";
 import {BlockNumbers} from "./libs/BlockNumbers.sol";
 import {CoreLib} from "./libs/CoreLib.sol";
 
@@ -27,7 +29,7 @@ import {CoreLib} from "./libs/CoreLib.sol";
  *         a trustless channel for signers to communicate public encryption keys amongst themselves
  *         in order to support asymmetric encryption schemes of the transaction data.
  */
-contract SafeSecretHarbour {
+contract SafeSecretHarbour is IERC165, ISafeSecretHarbour {
     using BlockNumbers for BlockNumbers.T;
     using BlockNumbers for BlockNumbers.Iterator;
 
@@ -53,6 +55,19 @@ contract SafeSecretHarbour {
      */
     mapping(uint256 chainId => mapping(address safe => mapping(uint256 nonce => mapping(address signer => BlockNumbers.T))))
         private _registrations;
+
+    // ------------------------------------------------------------------
+    // ERC-165 Implementation
+    // ------------------------------------------------------------------
+
+    /// @inheritdoc IERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure returns (bool) {
+        return
+            interfaceId == type(IERC165).interfaceId ||
+            interfaceId == type(ISafeSecretHarbour).interfaceId;
+    }
 
     // ------------------------------------------------------------------
     // External & public write functions

--- a/contracts/src/interfaces/ERC165.sol
+++ b/contracts/src/interfaces/ERC165.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.29;
+
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}

--- a/contracts/src/interfaces/ERC4337.sol
+++ b/contracts/src/interfaces/ERC4337.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.29;
+
 import {
     IEntryPoint
 } from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";

--- a/contracts/src/interfaces/Harbour.sol
+++ b/contracts/src/interfaces/Harbour.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.29;
+
+import {SafeTransactionRegistrationHandle} from "./Types.sol";
+
+/// @title Safe Secret Harbour Interface
+interface ISafeSecretHarbour {
+    function registerEncryptionKey(bytes32 encryptionKey) external;
+
+    function registerTransaction(
+        uint256 chainId,
+        address safe,
+        uint256 nonce,
+        bytes32 safeTxStructHash,
+        bytes calldata signature,
+        bytes calldata encryptedSafeTx
+    ) external returns (bytes32 uid);
+
+    function retrieveEncryptionKeys(
+        address[] calldata signers
+    ) external view returns (bytes32[] memory encryptionKeys);
+
+    function retrieveRegistrations(
+        uint256 chainId,
+        address safe,
+        uint256 nonce,
+        address signer,
+        uint256 start,
+        uint256 count
+    )
+        external
+        view
+        returns (
+            SafeTransactionRegistrationHandle[] memory page,
+            uint256 totalCount
+        );
+}

--- a/contracts/test/SafeSecretHarbour.spec.ts
+++ b/contracts/test/SafeSecretHarbour.spec.ts
@@ -25,7 +25,7 @@ describe("SafeInternationalHarbour", () => {
 		return { deployer, signer, alice, harbour, chainId, safe, decryptionKey, encryptionKey };
 	}
 
-	it("should report support the secret harbour interface", async () => {
+	it("should report support for the secret harbour interface", async () => {
 		const { harbour } = await loadFixture(deployFixture);
 
 		let secretHarbourId = "0x00000000";

--- a/contracts/test/SafeSecretHarbour.spec.ts
+++ b/contracts/test/SafeSecretHarbour.spec.ts
@@ -25,6 +25,21 @@ describe("SafeInternationalHarbour", () => {
 		return { deployer, signer, alice, harbour, chainId, safe, decryptionKey, encryptionKey };
 	}
 
+	it("should report support the secret harbour interface", async () => {
+		const { harbour } = await loadFixture(deployFixture);
+
+		let secretHarbourId = "0x00000000";
+		const secretHarbour = await ethers.getContractAt("ISafeSecretHarbour", harbour);
+		secretHarbour.interface.forEachFunction((func) => {
+			secretHarbourId = `0x${(BigInt(secretHarbourId) ^ BigInt(func.selector)).toString(16)}`;
+		});
+
+		expect(secretHarbourId).to.equal("0x8a56c054");
+		for (const interfaceId of ["0x01ffc9a7", "0x8a56c054"]) {
+			expect(await harbour.supportsInterface(interfaceId)).to.be.true;
+		}
+	});
+
 	it("should register a public encryption key", async () => {
 		const { signer, harbour, encryptionKey } = await loadFixture(deployFixture);
 


### PR DESCRIPTION
Harbour contracts going forward should identify themselves via ERC-165, this will allow clients to discover compatibility with features. For example:
- Does it support ERC4337 interface? Then enable relaying
- Does it support Secret harbour interface? then enable encryption
- etc.

The interface can then make configuration automatic based on a Harbour contract address.