### PR TITLE
Add Encryption Key Context

### DIFF
--- a/contracts/src/interfaces/Events.sol
+++ b/contracts/src/interfaces/Events.sol
@@ -59,11 +59,15 @@ event NewTransaction(
 /**
  * @notice Emitted whenever an encryption key is registered for a signer.
  *
- * @param signer        The signer for which the key was registered.
- * @param encryptionKey A 32-byte encryption key. The exact format of the key is left up to the
- *                      application.
+ * @param signer    The signer for which the key was registered.
+ * @param context   A 32-byte contract associated with the encryption key.
+ * @param publicKey A 32-byte encryption public key.
  */
-event EncryptionKeyRegistered(address indexed signer, bytes32 encryptionKey);
+event EncryptionKeyRegistered(
+    address indexed signer,
+    bytes32 context,
+    bytes32 publicKey
+);
 
 /**
  * @notice Emitted whenever a signed encrypted Safe transaction is registered.

--- a/contracts/src/interfaces/Harbour.sol
+++ b/contracts/src/interfaces/Harbour.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.29;
 
-import {SafeTransactionRegistrationHandle} from "./Types.sol";
+import {EncryptionKey, SafeTransactionRegistrationHandle} from "./Types.sol";
 
 /// @title Safe Secret Harbour Interface
 interface ISafeSecretHarbour {
-    function registerEncryptionKey(bytes32 encryptionKey) external;
+    function registerEncryptionKey(bytes32 context, bytes32 publicKey) external;
 
     function registerTransaction(
         uint256 chainId,
@@ -16,9 +16,13 @@ interface ISafeSecretHarbour {
         bytes calldata encryptedSafeTx
     ) external returns (bytes32 uid);
 
-    function retrieveEncryptionKeys(
+    function retrieveEncryptionPublicKeys(
         address[] calldata signers
-    ) external view returns (bytes32[] memory encryptionKeys);
+    ) external view returns (bytes32[] memory publicKeys);
+
+    function retrieveEncryptionKey(
+        address signers
+    ) external view returns (EncryptionKey memory encryptionKey);
 
     function retrieveRegistrations(
         uint256 chainId,

--- a/contracts/src/interfaces/Types.sol
+++ b/contracts/src/interfaces/Types.sol
@@ -39,6 +39,22 @@ struct SignatureDataWithTxHashIndex {
 }
 
 /**
+ * @dev A public encryption key.
+ *
+ * @custom:field context   An application-defined context. This can be used as a salt in
+ *                         deterministic encryption key derivation schemes (for example, it can be
+ *                         the `nonce` and `issuedAt` values for a Sign-in with Ethereum signature
+ *                         to be used as entropy for deriving an X25519 encryption key pair).
+ * @custom:field publicKey The public encryption key. Note that this contract does not enforce any
+ *                         specific key format, the only restriction is that the key must fit in 32
+ *                         bytes. The reference client implementation uses Curve25519 public keys.
+ */
+struct EncryptionKey {
+    bytes32 context;
+    bytes32 publicKey;
+}
+
+/**
  * @dev An encrypted Safe transaction registration handle.
  */
 struct SafeTransactionRegistrationHandle {


### PR DESCRIPTION
This PR adds a new `context` storage field to encryption keys. This can be used for storing a salt related to a deterministic key devivation mechanism, while allowing for key rotation.

Specifially, the reference harbour client will implement:

1. Compute a `Date.now()` issuance date
2. Request a SIWE signature with `issuedAt` set to the issuance date from step 1
3. Generate a public X25519 key using entropy from the signature in step 2.
4. `registerEncryptionKey(context: issuedAt, publicKey)`

This allows the key to be deterministically recomputed by reading the context on-chain, while also making it easy to rotate keys: you would just run through the process again, and store a new context and public key. Clients will know that the key rotated, and if you are connected with the same wallet to another browser, you can recompute the key.