### PR TITLE
Use Chain ID as EIP-712 Salt For Harbour

### DIFF
--- a/contracts/src/SafeSecretHarbour.sol
+++ b/contracts/src/SafeSecretHarbour.sol
@@ -116,6 +116,8 @@ contract SafeSecretHarbour is IERC165, ISafeSecretHarbour {
         bytes calldata signature
     ) external {
         bytes32 encryptionKeyHash = CoreLib.computeEncryptionKeyHash(
+            block.chainid,
+            address(this),
             context,
             publicKey
         );

--- a/contracts/src/interfaces/Constants.sol
+++ b/contracts/src/interfaces/Constants.sol
@@ -9,10 +9,13 @@ pragma solidity ^0.8.29;
 // https://github.com/safe-global/safe-smart-account/blob/b115c4c5fe23dca6aefeeccc73d312ddd23322c2/contracts/Safe.sol#L54-L63
 // These should cover Safe versions 1.3.0 and 1.4.1
 // keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
-bytes32 constant DOMAIN_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+bytes32 constant SAFE_DOMAIN_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
 
 // keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
 bytes32 constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
+
+// keccak256("EIP712Domain(address verifyingContract,bytes32 salt)")
+bytes32 constant HARBOUR_DOMAIN_TYPEHASH = 0x6268546d6d3d3a16ed8cfd22f4fe09a1d17f9af43838183ba533d41e284cf326;
 
 // keccak256("EncryptionKey(bytes32 context,bytes32 publicKey)")
 bytes32 constant ENCRYPTION_KEY_TYPEHASH = 0xc61c2d0b1f1942c20e1ecd68ca0337b62afaa25024fc73f2aad19b5696efb313;

--- a/contracts/test/SafeSecretHarbour.spec.ts
+++ b/contracts/test/SafeSecretHarbour.spec.ts
@@ -255,8 +255,8 @@ describe("SafeInternationalHarbour", () => {
 		const { chainId } = await ethers.provider.getNetwork();
 		const signature = await signer.signTypedData(
 			{
-				chainId,
 				verifyingContract: await harbour.getAddress(),
+				salt: ethers.toBeHex(chainId, 32),
 			},
 			{
 				EncryptionKey: [
@@ -278,8 +278,8 @@ describe("SafeInternationalHarbour", () => {
 		const { chainId } = await ethers.provider.getNetwork();
 		const signature = await signer.signTypedData(
 			{
-				chainId,
 				verifyingContract: await harbour.getAddress(),
+				salt: ethers.toBeHex(chainId, 32),
 			},
 			{
 				EncryptionKey: [


### PR DESCRIPTION
We added a mechanism to relay some harbour transactions on behalf of a user (specifically, the registration of encryption keys). This causes some UX friction with how it is current implemented, as you must request the wallet change to a new chain in order to sign a permission to upload an encryption key.

I decided to change the `salt` field to hold the chain ID instead of the expected chain for a couple of reasons:

- In the case of the encryption key, while it is being registed on `chainId`, it is actually meant for use on **other** chains
- This allows Wallet EIP-712 signatures without a chain ID which can be done when the wallet is connected to any network. In particular for Harbour this is nice, since you are connected to the network where your Safe is, and don't want to change networks just to register a new encryption key.

I don't think there are security downsides to this: the encryption key signature is not more or less replayable than before. Additionally, the encryption key signature is not meant for a specific chain anyway, so you can't really "fish" an encryption key registration on the wrong chain (which is what this field helps protect).
