### PR TITLE
Run All CI on `main`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,9 +2,7 @@ name: Contracts CI
 
 on:
   push:
-    paths:
-      - "contracts/**"
-      - ".github/workflows/**"
+    branches: ["main"]
   pull_request:
     paths:
       - "contracts/**"

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -3,9 +3,6 @@ name: Webapp CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "webapp/**"
-      - ".github/workflows/**"
   pull_request:
     paths:
       - "webapp/**"


### PR DESCRIPTION
This PR changes our workflows to run the complete CI on pushes to the `main` branch. This ensures that CI doesn't break for any part of the project whenever our default branch changes.

Since CI on the `push` branch doesn't get run for PRs, this means that we don't have to worry about this affecting DevX, it happens in the backgroud.
