### PR TITLE
[Secret Harbour]: Encryption Setup

### DIFF
--- a/webapp/src/components/Forms.tsx
+++ b/webapp/src/components/Forms.tsx
@@ -10,6 +10,7 @@ function FormItem<T extends FieldValues>({
 	error,
 	label,
 	placeholder,
+	disabled,
 	register,
 	className,
 }: {
@@ -17,6 +18,7 @@ function FormItem<T extends FieldValues>({
 	error: FieldError | undefined;
 	label: string;
 	placeholder?: string;
+	disabled?: boolean;
 	register: UseFormRegister<T>;
 	className?: string;
 }) {
@@ -33,6 +35,7 @@ function FormItem<T extends FieldValues>({
 				type="text"
 				{...register(id)}
 				placeholder={placeholder}
+				disabled={disabled}
 				className="mt-1 block w-full border border-gray-300 bg-white text-gray-900 rounded-md px-3 py-2 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:border-gray-900"
 			/>
 			{error && <p className="mt-1 text-sm text-red-600">{error.message}</p>}

--- a/webapp/src/components/settings/EncryptionForm.tsx
+++ b/webapp/src/components/settings/EncryptionForm.tsx
@@ -1,0 +1,89 @@
+import { ExternalLink } from "lucide-react";
+import { useCallback } from "react";
+import type { SettingsFormData } from "@/components/settings/SettingsForm";
+import { useSession } from "@/contexts/SessionContext";
+import { useBrowserProvider } from "@/hooks/useBrowserProvider";
+import { useRelayerBalanceInfo } from "@/hooks/useRelayerBalanceInfo";
+import { useSignAndRegisterEncryptionKey } from "@/hooks/useSignAndRegisterEncryptionKey";
+
+interface EncryptionFormParameters {
+	currentSettings: Partial<SettingsFormData>;
+}
+
+function EncryptionForm({ currentSettings }: EncryptionFormParameters) {
+	const browserProvider = useBrowserProvider();
+	const { keys, pendingRegistration, isUpdating, connect, create, error } =
+		useSession();
+	const { ready, isSubmitting, signAndRegister } =
+		useSignAndRegisterEncryptionKey({
+			browserProvider,
+			currentSettings,
+			onRegistered: connect,
+		});
+	const { data: relayerBalance } = useRelayerBalanceInfo(currentSettings);
+
+	const handleSignin = useCallback(async () => {
+		create();
+	}, [create]);
+
+	return (
+		<div>
+			<span className="block text-sm font-medium text-gray-700 mb-1">
+				Encryption {"🔐"}
+			</span>
+			{!keys && (
+				<button
+					type="button"
+					onClick={handleSignin}
+					disabled={isUpdating}
+					className="px-4 py-2 text-sm font-medium bg-black text-white rounded hover:bg-gray-800 transition disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					Sign In
+				</button>
+			)}
+			{keys && (
+				<div className="flex space-x-2 pl-4">
+					<span className="text-sm">
+						Public Key: <code>{keys.encryption.publicKeyHex}</code>
+					</span>
+				</div>
+			)}
+			{keys && (
+				<div className="flex space-x-2 pl-4">
+					<span className="text-sm">
+						Notary: <code>{keys.relayer.address}</code>{" "}
+						{relayerBalance?.needsFunding && relayerBalance?.faucet ? (
+							<a
+								className="ml-3 underline"
+								target="_blank"
+								rel="noopener noreferrer"
+								href={relayerBalance.faucet}
+							>
+								<ExternalLink className="inline" size={16} /> fund
+							</a>
+						) : (
+							<span className="ml-3 text-gray-700">
+								{relayerBalance?.formatted}
+							</span>
+						)}
+					</span>
+					{pendingRegistration && (
+						<button
+							type="button"
+							disabled={
+								relayerBalance?.needsFunding !== false || !ready || isSubmitting
+							}
+							onClick={signAndRegister}
+							className="px-4 py-2 text-sm font-medium bg-black text-white rounded hover:bg-gray-800 transition ml-auto disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Register
+						</button>
+					)}
+				</div>
+			)}
+			{error && <p className="mt-1 text-sm text-red-600">{error?.message}</p>}
+		</div>
+	);
+}
+
+export { EncryptionForm, type EncryptionFormParameters };

--- a/webapp/src/components/settings/EncryptionForm.tsx
+++ b/webapp/src/components/settings/EncryptionForm.tsx
@@ -31,7 +31,7 @@ function EncryptionForm({ currentSettings }: EncryptionFormParameters) {
 			<span className="block text-sm font-medium text-gray-700 mb-1">
 				Encryption {"🔐"}
 			</span>
-			{!keys && (
+			{!keys ? (
 				<button
 					type="button"
 					onClick={handleSignin}
@@ -40,46 +40,47 @@ function EncryptionForm({ currentSettings }: EncryptionFormParameters) {
 				>
 					Sign In
 				</button>
-			)}
-			{keys && (
-				<div className="flex space-x-2 pl-4">
-					<span className="text-sm">
-						Public Key: <code>{keys.encryption.publicKeyHex}</code>
-					</span>
-				</div>
-			)}
-			{keys && (
-				<div className="flex space-x-2 pl-4">
-					<span className="text-sm">
-						Notary: <code>{keys.relayer.address}</code>{" "}
-						{relayerBalance?.needsFunding && relayerBalance?.faucet ? (
-							<a
-								className="ml-3 underline"
-								target="_blank"
-								rel="noopener noreferrer"
-								href={relayerBalance.faucet}
+			) : (
+				<>
+					<div className="flex space-x-2 pl-4">
+						<span className="text-sm">
+							Public Key: <code>{keys.encryption.publicKeyHex}</code>
+						</span>
+					</div>
+					<div className="flex space-x-2 pl-4">
+						<span className="text-sm">
+							Notary: <code>{keys.relayer.address}</code>{" "}
+							{relayerBalance?.needsFunding && relayerBalance?.faucet ? (
+								<a
+									className="ml-3 underline"
+									target="_blank"
+									rel="noopener noreferrer"
+									href={relayerBalance.faucet}
+								>
+									<ExternalLink className="inline" size={16} /> fund
+								</a>
+							) : (
+								<span className="ml-3 text-gray-700">
+									{relayerBalance?.formatted ?? "Loading balance..."}
+								</span>
+							)}
+						</span>
+						{pendingRegistration && (
+							<button
+								type="button"
+								disabled={
+									relayerBalance?.needsFunding !== false ||
+									!ready ||
+									isSubmitting
+								}
+								onClick={signAndRegister}
+								className="px-4 py-2 text-sm font-medium bg-black text-white rounded hover:bg-gray-800 transition ml-auto disabled:opacity-50 disabled:cursor-not-allowed"
 							>
-								<ExternalLink className="inline" size={16} /> fund
-							</a>
-						) : (
-							<span className="ml-3 text-gray-700">
-								{relayerBalance?.formatted}
-							</span>
+								Register
+							</button>
 						)}
-					</span>
-					{pendingRegistration && (
-						<button
-							type="button"
-							disabled={
-								relayerBalance?.needsFunding !== false || !ready || isSubmitting
-							}
-							onClick={signAndRegister}
-							className="px-4 py-2 text-sm font-medium bg-black text-white rounded hover:bg-gray-800 transition ml-auto disabled:opacity-50 disabled:cursor-not-allowed"
-						>
-							Register
-						</button>
-					)}
-				</div>
+					</div>
+				</>
 			)}
 			{error && <p className="mt-1 text-sm text-red-600">{error?.message}</p>}
 		</div>

--- a/webapp/src/components/settings/SettingsForm.tsx
+++ b/webapp/src/components/settings/SettingsForm.tsx
@@ -103,14 +103,14 @@ function SettingsForm({
 				register={register}
 				error={errors.harbourAddress}
 				label="Harbour Address"
-				placeholder="0x...."
+				placeholder="0x..."
 			/>
 			<FormItem
 				id="quotaManagerAddress"
 				register={register}
 				error={errors.quotaManagerAddress}
 				label="Quota Manager Address"
-				placeholder="0x...."
+				placeholder="0x..."
 			/>
 			<FormItem
 				id="bundlerUrl"

--- a/webapp/src/components/settings/SettingsForm.tsx
+++ b/webapp/src/components/settings/SettingsForm.tsx
@@ -103,14 +103,14 @@ function SettingsForm({
 				register={register}
 				error={errors.harbourAddress}
 				label="Harbour Address"
-				placeholder="0x..."
+				placeholder="0x…"
 			/>
 			<FormItem
 				id="quotaManagerAddress"
 				register={register}
 				error={errors.quotaManagerAddress}
 				label="Quota Manager Address"
-				placeholder="0x..."
+				placeholder="0x…"
 			/>
 			<FormItem
 				id="bundlerUrl"

--- a/webapp/src/components/settings/WakuForm.tsx
+++ b/webapp/src/components/settings/WakuForm.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
+import type { SettingsFormData } from "@/components/settings/SettingsForm";
 import { useWaku, WakuState } from "@/contexts/WakuContext";
+import {
+	getHarbourChainId,
+	HARBOUR_ADDRESS,
+	HARBOUR_CHAIN_ID,
+} from "@/lib/harbour";
 
 const mapWakuState = (status: WakuState | undefined): string => {
 	switch (status) {
@@ -16,8 +22,15 @@ const mapWakuState = (status: WakuState | undefined): string => {
 	}
 };
 
-function WakuForm() {
+interface WakuFormProps {
+	currentSettings: Partial<SettingsFormData>;
+}
+
+function WakuForm({
+	currentSettings: { harbourAddress, rpcUrl },
+}: WakuFormProps) {
 	const [status, setStatus] = useState<WakuState>();
+	const [supported, setSupported] = useState<boolean | null>(null);
 	const waku = useWaku();
 
 	useEffect(() => {
@@ -26,6 +39,32 @@ function WakuForm() {
 			waku.unwatchStatus(setStatus);
 		};
 	}, [waku]);
+
+	// Waku does not support setting alternative harbour deployments, so read
+	// the harbour address and chain from the current settings and decide
+	// whether or not Waku is supported.
+	useEffect(() => {
+		let cancelled = false;
+		getHarbourChainId({ rpcUrl }).then((chainId) => {
+			if (cancelled) {
+				return;
+			}
+
+			const customHarbour =
+				harbourAddress && harbourAddress !== HARBOUR_ADDRESS;
+			const customChain = chainId !== HARBOUR_CHAIN_ID;
+			if (customHarbour || customChain) {
+				waku.disable();
+				waku.stop();
+				setSupported(false);
+			} else {
+				setSupported(true);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [harbourAddress, rpcUrl, waku]);
 
 	const toggleWaku = () => {
 		if (status === WakuState.DISABLED) {
@@ -47,6 +86,7 @@ function WakuForm() {
 					type="checkbox"
 					checked={status !== WakuState.DISABLED}
 					onClick={toggleWaku}
+					disabled={supported !== true}
 					value=""
 					className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-sm focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
 				/>

--- a/webapp/src/contexts/SessionContext.tsx
+++ b/webapp/src/contexts/SessionContext.tsx
@@ -1,0 +1,226 @@
+import { ethers, type Wallet } from "ethers";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+	useTransition,
+} from "react";
+import { useBrowserProvider } from "@/hooks/useBrowserProvider";
+import { useHarbourRpcProvider } from "@/hooks/useRpcProvider";
+import {
+	type EncryptionKey,
+	fetchEncryptionKey,
+	type HarbourContractSettings,
+} from "@/lib/harbour";
+import {
+	deserializeSession,
+	type Session,
+	serializeSession,
+	signinToSession,
+} from "@/lib/session";
+
+const STORAGE_KEY_PREFIX = "session.v1";
+
+type Address = string;
+type Hex = string;
+
+interface SessionStorageKey {
+	chainId: bigint;
+	address: Address;
+}
+
+interface CryptoKeyPairWithHex extends CryptoKeyPair {
+	publicKeyHex: Hex;
+}
+
+interface SessionKeys {
+	encryption: CryptoKeyPairWithHex;
+	relayer: Wallet;
+}
+
+interface SessionState {
+	session: Session;
+	hasPendingRegistration: boolean;
+}
+
+interface SessionValue {
+	keys: SessionKeys | null;
+	pendingRegistration: EncryptionKey | null;
+	connect: (settings?: HarbourContractSettings) => void;
+	create: (settings?: HarbourContractSettings) => void;
+	disconnect: () => void;
+	connected: boolean;
+	isUpdating: boolean;
+	error: Error | null;
+}
+
+function storageKeyFor({ chainId, address }: SessionStorageKey): string {
+	return `${STORAGE_KEY_PREFIX}:${chainId}@${ethers.getAddress(address)}`;
+}
+
+async function loadSession(key: SessionStorageKey): Promise<Session | null> {
+	try {
+		const storageKey = storageKeyFor(key);
+		const encoded = localStorage.getItem(storageKey) ?? "";
+		return await deserializeSession(encoded);
+	} catch {
+		return null;
+	}
+}
+
+function storeSession(key: SessionStorageKey, session: Session) {
+	const storageKey = storageKeyFor(key);
+	const encoded = serializeSession(session);
+	localStorage.setItem(storageKey, encoded);
+}
+
+function onchainMatchesSession(
+	onchain: EncryptionKey,
+	{ registration }: Pick<Session, "registration">,
+) {
+	return (
+		onchain.context === registration.context &&
+		onchain.publicKey === registration.publicKey
+	);
+}
+
+function isError(o: unknown): o is Error {
+	return Object.prototype.toString.call(o) === "[object Error]";
+}
+
+const SessionContext = createContext<SessionValue | null>(null);
+
+function SessionProvider({ children }: { children: ReactNode }) {
+	const wallet = useBrowserProvider();
+	const { provider } = useHarbourRpcProvider();
+
+	const [session, setSession] = useState<SessionState | null>(null);
+	const [error, setError] = useState<Error | null>(null);
+	const [isUpdating, startUpdate] = useTransition();
+
+	const update = useCallback((handler: () => Promise<SessionState | null>) => {
+		setError(null);
+		startUpdate(async () => {
+			try {
+				const session = await handler();
+				setSession(session);
+			} catch (err) {
+				console.error(err);
+				setSession(null);
+				setError(isError(err) ? err : new Error(`${err}`));
+			}
+		});
+	}, []);
+
+	const connect = useCallback(
+		(currentSettings?: HarbourContractSettings) =>
+			update(async () => {
+				if (!wallet || !provider) {
+					return null;
+				}
+
+				const signer = await wallet.getSigner();
+				const address = await signer.getAddress();
+				const { chainId } = await provider.getNetwork();
+				const onchain = await fetchEncryptionKey(address, currentSettings);
+				const session = await loadSession({ chainId, address });
+				if (onchain === null || session === null) {
+					return null;
+				}
+
+				// We need to make sure that the onchain registration (if there
+				// is one), matches what we have in local storage, otherwise
+				// this means either our local storage copy is outdated and
+				// needs to be rotated.
+				if (onchain.registered && !onchainMatchesSession(onchain, session)) {
+					return null;
+				}
+
+				return {
+					session,
+					hasPendingRegistration: !onchain.registered,
+				};
+			}),
+		[update, wallet, provider],
+	);
+
+	const create = useCallback(
+		(currentSettings?: HarbourContractSettings) =>
+			update(async () => {
+				if (!wallet || !provider) {
+					throw new Error(
+						"Session creation is not available without a connected wallet",
+					);
+				}
+
+				const signer = await wallet.getSigner();
+				const address = await signer.getAddress();
+				const { chainId } = await provider.getNetwork();
+				const onchain = await fetchEncryptionKey(address, currentSettings);
+				const session = await signinToSession({
+					signer,
+					chainId,
+					onchain: onchain?.registered ? onchain : undefined,
+				});
+				storeSession({ chainId, address }, session);
+				return {
+					session,
+					hasPendingRegistration:
+						!onchain?.registered || !onchainMatchesSession(onchain, session),
+				};
+			}),
+		[update, wallet, provider],
+	);
+
+	const disconnect = useCallback(() => {
+		setSession(null);
+		setError(null);
+	}, []);
+
+	const value = useMemo(
+		() => ({
+			connected: session !== null,
+			keys: session
+				? {
+						encryption: {
+							...session.session.encryption,
+							publicKeyHex: session.session.registration.publicKey,
+						},
+						relayer: session.session.relayer,
+					}
+				: null,
+			pendingRegistration: session?.hasPendingRegistration
+				? session.session.registration
+				: null,
+			connect,
+			create,
+			disconnect,
+			isUpdating,
+			error,
+		}),
+		[session, connect, create, disconnect, isUpdating, error],
+	);
+
+	useEffect(() => {
+		connect();
+	}, [connect]);
+
+	return (
+		<SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+	);
+}
+
+function useSession(): SessionValue {
+	const value = useContext(SessionContext);
+	if (value === null) {
+		throw new Error("useSession must be used within a SessionContext provider");
+	}
+	return value;
+}
+
+export type { SessionKeys, SessionValue };
+export { SessionProvider, useSession };

--- a/webapp/src/hooks/useRelayerBalanceInfo.ts
+++ b/webapp/src/hooks/useRelayerBalanceInfo.ts
@@ -1,16 +1,10 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
-import { ethers } from "ethers";
 import type { SettingsFormData } from "@/components/settings/SettingsForm";
 import { useSession } from "@/contexts/SessionContext";
 import { useHarbourRpcProvider } from "@/hooks/useRpcProvider";
+import { getRelayerBalanceInfo, type RelayerBalanceInfo } from "@/lib/relaying";
 
 type UseRelayerBalanceInfoProps = Pick<Partial<SettingsFormData>, "rpcUrl">;
-
-interface RelayerBalanceInfo {
-	formatted: string;
-	needsFunding: boolean;
-	faucet?: string;
-}
 
 /**
  * Custom React Query hook to fetch the current relayer balance information.
@@ -27,22 +21,11 @@ function useRelayerBalanceInfo(
 			keys?.relayer?.address,
 			currentSettings?.rpcUrl,
 		],
-		queryFn: async () => {
+		queryFn: () => {
 			if (!provider || !keys) {
 				return null;
 			}
-
-			const { chainId } = await provider.getNetwork();
-			const balance = await provider.getBalance(keys.relayer);
-
-			return {
-				formatted: `Ξ${ethers.formatEther(balance)}`,
-				needsFunding: balance === 0n,
-				faucet:
-					chainId === 100n
-						? `https://faucet.gnosischain.com/?address=${keys.relayer.address}`
-						: undefined,
-			};
+			return getRelayerBalanceInfo({ relayer: keys.relayer.address, provider });
 		},
 		enabled: !!provider && !!keys,
 		staleTime: 2500,

--- a/webapp/src/hooks/useRelayerBalanceInfo.ts
+++ b/webapp/src/hooks/useRelayerBalanceInfo.ts
@@ -1,0 +1,53 @@
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { ethers } from "ethers";
+import type { SettingsFormData } from "@/components/settings/SettingsForm";
+import { useSession } from "@/contexts/SessionContext";
+import { useHarbourRpcProvider } from "@/hooks/useRpcProvider";
+
+type UseRelayerBalanceInfoProps = Pick<Partial<SettingsFormData>, "rpcUrl">;
+
+interface RelayerBalanceInfo {
+	formatted: string;
+	needsFunding: boolean;
+	faucet?: string;
+}
+
+/**
+ * Custom React Query hook to fetch the current relayer balance information.
+ */
+function useRelayerBalanceInfo(
+	currentSettings: UseRelayerBalanceInfoProps,
+): UseQueryResult<RelayerBalanceInfo | null, Error> {
+	const { keys } = useSession();
+	const { provider } = useHarbourRpcProvider(currentSettings);
+
+	return useQuery<RelayerBalanceInfo | null, Error>({
+		queryKey: [
+			"relayerBalance",
+			keys?.relayer?.address,
+			currentSettings?.rpcUrl,
+		],
+		queryFn: async () => {
+			if (!provider || !keys) {
+				return null;
+			}
+
+			const { chainId } = await provider.getNetwork();
+			const balance = await provider.getBalance(keys.relayer);
+
+			return {
+				formatted: `Ξ${ethers.formatEther(balance)}`,
+				needsFunding: balance === 0n,
+				faucet:
+					chainId === 100n
+						? `https://faucet.gnosischain.com/?address=${keys.relayer.address}`
+						: undefined,
+			};
+		},
+		enabled: !!provider && !!keys,
+		staleTime: 2500,
+		refetchInterval: 5000,
+	});
+}
+
+export { useRelayerBalanceInfo };

--- a/webapp/src/hooks/useRpcProvider.test.ts
+++ b/webapp/src/hooks/useRpcProvider.test.ts
@@ -28,12 +28,8 @@ describe("useHarbourRpcProvider", () => {
 				.mockResolvedValue({ rpcUrl: "https://rpc.harbour" }),
 		}));
 		vi.doMock("../lib/chains", () => ({ getRpcUrlByChainId: vi.fn() }));
-		const { useHarbourRpcProvider, DEFAULT_PROVIDER_OPTIONS } = await import(
-			"./useRpcProvider"
-		);
-		const { result } = renderHook(() =>
-			useHarbourRpcProvider(DEFAULT_PROVIDER_OPTIONS),
-		);
+		const { useHarbourRpcProvider } = await import("./useRpcProvider");
+		const { result } = renderHook(() => useHarbourRpcProvider());
 		await waitFor(() => {
 			expect(result.current.provider).not.toBeNull();
 			expect(result.current.error).toBeNull();
@@ -48,12 +44,8 @@ describe("useHarbourRpcProvider", () => {
 		vi.doMock("../lib/chains", () => ({
 			getRpcUrlByChainId: vi.fn().mockResolvedValue("https://rpc.fallback"),
 		}));
-		const { useHarbourRpcProvider, DEFAULT_PROVIDER_OPTIONS } = await import(
-			"./useRpcProvider"
-		);
-		const { result } = renderHook(() =>
-			useHarbourRpcProvider(DEFAULT_PROVIDER_OPTIONS),
-		);
+		const { useHarbourRpcProvider } = await import("./useRpcProvider");
+		const { result } = renderHook(() => useHarbourRpcProvider());
 		await waitFor(() => {
 			expect(result.current.provider).not.toBeNull();
 			expect(result.current.error).toBeNull();

--- a/webapp/src/hooks/useRpcProvider.ts
+++ b/webapp/src/hooks/useRpcProvider.ts
@@ -1,9 +1,12 @@
 import type { JsonRpcApiProvider, JsonRpcApiProviderOptions } from "ethers";
 import { JsonRpcProvider } from "ethers";
 import { useCallback, useEffect, useState } from "react";
-import { loadCurrentSettings } from "@/components/settings/SettingsForm";
+import {
+	loadCurrentSettings,
+	type SettingsFormData,
+} from "@/components/settings/SettingsForm";
+import { getRpcUrlByChainId } from "@/lib/chains";
 import { HARBOUR_CHAIN_ID } from "@/lib/harbour";
-import { getRpcUrlByChainId } from "../lib/chains";
 
 /**
  * Represents the result of the useChainlistRpcProvider hook.
@@ -40,13 +43,19 @@ export function useChainlistRpcProvider(
 }
 
 export function useHarbourRpcProvider(
+	currentSettings:
+		| Pick<Partial<SettingsFormData>, "rpcUrl">
+		| undefined = undefined,
 	providerOptions: JsonRpcApiProviderOptions = DEFAULT_PROVIDER_OPTIONS,
 ): UseChainlistRpcProviderResult {
+	const settingsProvided = currentSettings !== undefined;
+	const currentRpcUrl = currentSettings?.rpcUrl;
 	const loadRpcUrl = useCallback(async (): Promise<string> => {
-		const currentSettings = await loadCurrentSettings();
-		if (currentSettings.rpcUrl) return currentSettings.rpcUrl;
-		return getRpcUrlByChainId(HARBOUR_CHAIN_ID);
-	}, []);
+		const { rpcUrl } = settingsProvided
+			? { rpcUrl: currentRpcUrl }
+			: ((await loadCurrentSettings()) ?? {});
+		return rpcUrl ?? getRpcUrlByChainId(HARBOUR_CHAIN_ID);
+	}, [settingsProvided, currentRpcUrl]);
 	return useRpcProvider(HARBOUR_CHAIN_ID, providerOptions, loadRpcUrl);
 }
 

--- a/webapp/src/hooks/useSignAndRegisterEncryptionKey.ts
+++ b/webapp/src/hooks/useSignAndRegisterEncryptionKey.ts
@@ -1,0 +1,71 @@
+import type { BrowserProvider } from "ethers";
+import { useCallback, useState } from "react";
+import { useSession } from "@/contexts/SessionContext";
+import {
+	type HarbourContractSettings,
+	signAndRegisterEncryptionKey,
+} from "@/lib/harbour";
+
+interface SignAndRegisterEncryptionKeyProps {
+	browserProvider?: BrowserProvider;
+	currentSettings?: HarbourContractSettings;
+	onRegistered?: () => void;
+}
+
+interface SignAndRegisterEncryptionKeyReturn {
+	ready: boolean;
+	isSubmitting: boolean;
+	error: string | null;
+	signAndRegister: () => void;
+}
+
+export function useSignAndRegisterEncryptionKey({
+	browserProvider,
+	currentSettings,
+	onRegistered,
+}: SignAndRegisterEncryptionKeyProps): SignAndRegisterEncryptionKeyReturn {
+	const { keys, pendingRegistration } = useSession();
+	const ready = !!browserProvider && !!keys && !!pendingRegistration;
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const signAndRegister = useCallback(async () => {
+		setIsSubmitting(true);
+		setError(null);
+		try {
+			if (!browserProvider || !keys || !pendingRegistration) {
+				throw new Error(
+					"cannot register without pending registration or relayer",
+				);
+			}
+
+			await signAndRegisterEncryptionKey({
+				walletProvider: browserProvider,
+				registration: pendingRegistration,
+				sessionKeys: keys,
+				currentSettings,
+			});
+			onRegistered?.();
+		} catch (err: unknown) {
+			const message =
+				err instanceof Error
+					? err.message
+					: "Encryption key registration failed";
+			setError(message);
+		} finally {
+			setIsSubmitting(false);
+		}
+	}, [
+		browserProvider,
+		currentSettings,
+		onRegistered,
+		keys,
+		pendingRegistration,
+	]);
+	return {
+		ready,
+		isSubmitting,
+		error,
+		signAndRegister,
+	};
+}

--- a/webapp/src/hooks/useSupportsEncryption.ts
+++ b/webapp/src/hooks/useSupportsEncryption.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	type HarbourContractSettings,
+	supportsEncryption,
+} from "@/lib/harbour";
+
+/**
+ * Hook for whether or not the currently configured Harbour contract supports
+ * encryption.
+ */
+export function useSupportsEncryption({
+	harbourAddress,
+	rpcUrl,
+}: HarbourContractSettings = {}) {
+	return useQuery<boolean, Error>({
+		queryKey: ["supportsSecretHarbour", harbourAddress, rpcUrl],
+		queryFn: () => supportsEncryption({ harbourAddress, rpcUrl }),
+	});
+}

--- a/webapp/src/lib/harbour.test.ts
+++ b/webapp/src/lib/harbour.test.ts
@@ -1,4 +1,9 @@
-import type { ContractRunner, JsonRpcApiProvider, Network } from "ethers";
+import type {
+	ContractRunner,
+	InterfaceAbi,
+	JsonRpcApiProvider,
+	Network,
+} from "ethers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mocks
@@ -71,16 +76,18 @@ vi.mock("ethers", async () => {
 
 	class MockContract {
 		address: string;
-		abi: Interface;
+		abi: InterfaceAbi;
 		runner: null | ContractRunner;
+		interface: Interface;
 		constructor(
 			address: string,
-			abi: Interface,
+			abi: InterfaceAbi,
 			runner?: null | ContractRunner,
 		) {
 			this.address = address;
 			this.abi = abi;
 			this.runner = runner as ContractRunner;
+			this.interface = new actual.ethers.Interface(abi);
 		}
 		enqueueTransaction = vi
 			.fn()
@@ -88,7 +95,6 @@ vi.mock("ethers", async () => {
 		getAddress = vi.fn(async () => this.address);
 		TRUSTED_PAYMASTER = vi.fn(async () => "0xPAYMASTER");
 		SUPPORTED_ENTRYPOINT = vi.fn(async () => "0xENTRY");
-		interface = { encodeFunctionData: vi.fn(() => "0xabc") };
 	}
 
 	return {

--- a/webapp/src/lib/relaying.ts
+++ b/webapp/src/lib/relaying.ts
@@ -1,0 +1,57 @@
+import { ethers, type JsonRpcApiProvider } from "ethers";
+
+type Address = string;
+
+/**
+ * Relayer balance information.
+ */
+interface RelayerBalanceInfo {
+	formatted: string;
+	needsFunding: boolean;
+	faucet?: string;
+}
+
+/**
+ * Custom React Query hook to fetch the current relayer balance information.
+ */
+async function getRelayerBalanceInfo({
+	relayer,
+	provider,
+}: {
+	relayer: Address;
+	provider: JsonRpcApiProvider;
+}): Promise<RelayerBalanceInfo> {
+	const { chainId } = await provider.getNetwork();
+	const symbol = getNativeCurrencySymbol({ chainId });
+	const balance = await provider.getBalance(relayer);
+	const faucet = getFaucetUrl({ address: relayer, chainId });
+
+	return {
+		formatted: `${symbol} ${ethers.formatEther(balance)}`,
+		needsFunding: balance === 0n,
+		faucet: faucet,
+	};
+}
+
+function getNativeCurrencySymbol({ chainId }: { chainId: bigint }) {
+	if (chainId === 100n) {
+		return "XDAI";
+	}
+	return "Ξ";
+}
+
+function getFaucetUrl({
+	address,
+	chainId,
+}: {
+	address: Address;
+	chainId: bigint;
+}) {
+	if (chainId === 100n) {
+		return `https://faucet.gnosischain.com/?address=${address}`;
+	}
+	return undefined;
+}
+
+export type { RelayerBalanceInfo };
+export { getRelayerBalanceInfo };

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -11,6 +11,7 @@ import { routeTree } from "./routeTree.gen";
 import "./lib/onboard";
 
 import "./styles.css";
+import { SessionProvider } from "./contexts/SessionContext.tsx";
 import { WakuProvider } from "./contexts/WakuContext.tsx";
 import reportWebVitals from "./reportWebVitals.ts";
 
@@ -44,11 +45,13 @@ if (rootElement && !rootElement.innerHTML) {
 		<StrictMode>
 			<TanstackQuery.Provider>
 				<ErrorBoundary>
-					<WakuProvider>
-						<WalletConnectProvider router={router}>
-							<RouterProvider router={router} />
-						</WalletConnectProvider>
-					</WakuProvider>
+					<SessionProvider>
+						<WakuProvider>
+							<WalletConnectProvider router={router}>
+								<RouterProvider router={router} />
+							</WalletConnectProvider>
+						</WakuProvider>
+					</SessionProvider>
 				</ErrorBoundary>
 			</TanstackQuery.Provider>
 		</StrictMode>,

--- a/webapp/src/routes/settings.tsx
+++ b/webapp/src/routes/settings.tsx
@@ -2,11 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ConditionalBackButton } from "@/components/BackButton";
 import { Box, Container, ContainerTitle } from "@/components/Groups";
 import { QuotaOverview } from "@/components/harbour/QuotaOverview";
+import { EncryptionForm } from "@/components/settings/EncryptionForm";
 import {
 	SettingsForm,
 	useCurrentSettings,
 } from "@/components/settings/SettingsForm";
 import { WakuForm } from "@/components/settings/WakuForm";
+import { useSupportsEncryption } from "@/hooks/useSupportsEncryption";
 
 /**
  * Page component for the Harbour settings.
@@ -22,29 +24,37 @@ export const Route = createFileRoute("/settings")({
  */
 export function SettingsPage() {
 	const [currentSettings, loadSettings] = useCurrentSettings();
+	const { data: supportsEncryption } = useSupportsEncryption(currentSettings);
 
 	return (
 		<Container>
 			<ConditionalBackButton />
 			<ContainerTitle>Settings</ContainerTitle>
-			<Box>
-				<WakuForm />
-			</Box>
-			<Box className="mt-4">
-				{currentSettings ? (
-					<SettingsForm
-						currentSettings={currentSettings}
-						onSubmitted={loadSettings}
-					/>
-				) : (
-					"Loading..."
-				)}
-			</Box>
-			{currentSettings?.quotaManagerAddress && (
-				<QuotaOverview
-					quotaManagerAddress={currentSettings.quotaManagerAddress}
-					className="mt-4"
-				/>
+			{currentSettings ? (
+				<>
+					<Box>
+						<WakuForm currentSettings={currentSettings} />
+					</Box>
+					{supportsEncryption && (
+						<Box className="mt-4">
+							<EncryptionForm currentSettings={currentSettings} />
+						</Box>
+					)}
+					<Box className="mt-4">
+						<SettingsForm
+							currentSettings={currentSettings}
+							onSubmitted={loadSettings}
+						/>
+					</Box>
+					{currentSettings.quotaManagerAddress && (
+						<QuotaOverview
+							quotaManagerAddress={currentSettings.quotaManagerAddress}
+							className="mt-4"
+						/>
+					)}
+				</>
+			) : (
+				<Box>Loading...</Box>
 			)}
 		</Container>
 	);


### PR DESCRIPTION
This PR ports the encryption setup changes from #77 to `main`. Currently, the implementation supports:

- Configuring an encrypted harbour contract in the settings
- Signing in to your session with your wallet
- Registering the encryption key onchain
- Automatically disabling Waku when the encrypted harbour is used

Note that this only establishes session credentials, but does not implement any interactions with the Secret Harbour contract.
