### PR TITLE
[Secret Harbour]: Enqueue Encrypted Transaction

### DIFF
--- a/webapp/src/components/transaction-forms/BatchTransactionForm.test.tsx
+++ b/webapp/src/components/transaction-forms/BatchTransactionForm.test.tsx
@@ -41,6 +41,7 @@ describe("BatchTransactionForm", () => {
 				browserProvider={browserProvider}
 				config={config}
 				rpcProvider={rpcProvider}
+				encryptedQueue={null}
 			/>,
 		);
 		expect(
@@ -78,6 +79,7 @@ describe("BatchTransactionForm", () => {
 				browserProvider={browserProvider}
 				config={config}
 				rpcProvider={rpcProvider}
+				encryptedQueue={null}
 			/>,
 		);
 		expect(screen.getByText(/Batch Transactions/)).toBeInTheDocument();

--- a/webapp/src/components/transaction-forms/BatchTransactionForm.tsx
+++ b/webapp/src/components/transaction-forms/BatchTransactionForm.tsx
@@ -13,6 +13,7 @@ export function BatchTransactionForm({
 	chainId,
 	browserProvider,
 	config,
+	encryptedQueue,
 }: CommonTransactionFormProps) {
 	const { getBatch, removeTransaction, clearBatch } = useBatch();
 
@@ -32,6 +33,7 @@ export function BatchTransactionForm({
 		chainId,
 		browserProvider,
 		config,
+		encryptedQueue,
 		parser,
 		onEnqueued: () => {
 			clearBatch(safeAddress, chainId);

--- a/webapp/src/components/transaction-forms/ERC20TransferForm.test.tsx
+++ b/webapp/src/components/transaction-forms/ERC20TransferForm.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
 	rpcProvider,
 	config,
 	tokenAddress: "0xToken",
+	encryptedQueue: null,
 };
 
 describe("ERC20TransferForm", () => {

--- a/webapp/src/components/transaction-forms/ERC20TransferForm.tsx
+++ b/webapp/src/components/transaction-forms/ERC20TransferForm.tsx
@@ -36,6 +36,7 @@ export function ERC20TransferForm({
 	browserProvider,
 	rpcProvider,
 	config,
+	encryptedQueue,
 	tokenAddress: initialTokenAddress,
 }: ERC20TransferFormProps) {
 	const {
@@ -87,6 +88,7 @@ export function ERC20TransferForm({
 		chainId,
 		browserProvider,
 		config,
+		encryptedQueue,
 		parser,
 	});
 

--- a/webapp/src/components/transaction-forms/NativeTransferForm.test.tsx
+++ b/webapp/src/components/transaction-forms/NativeTransferForm.test.tsx
@@ -15,6 +15,7 @@ const config = {
 	modules: [],
 	guard: "0xGuard",
 	singleton: "0xSingleton",
+	encryptedQueue: null,
 };
 
 describe("NativeTransferForm", () => {
@@ -51,6 +52,7 @@ describe("NativeTransferForm", () => {
 				browserProvider={browserProvider}
 				rpcProvider={rpcProvider}
 				config={config}
+				encryptedQueue={null}
 			/>,
 		);
 		expect(screen.getByText(/Recipient Address/)).toBeInTheDocument();
@@ -91,6 +93,7 @@ describe("NativeTransferForm", () => {
 				browserProvider={browserProvider}
 				rpcProvider={rpcProvider}
 				config={config}
+				encryptedQueue={null}
 			/>,
 		);
 		expect(screen.getByText(/Balance: 1.0 ETH/)).toBeInTheDocument();

--- a/webapp/src/components/transaction-forms/NativeTransferForm.tsx
+++ b/webapp/src/components/transaction-forms/NativeTransferForm.tsx
@@ -34,12 +34,14 @@ export function NativeTransferForm({
 	browserProvider,
 	rpcProvider,
 	config,
+	encryptedQueue,
 }: CommonTransactionFormProps) {
 	const { isSubmitting, error, txHash, signAndEnqueue } = useSignAndEnqueue({
 		safeAddress,
 		chainId,
 		browserProvider,
 		config,
+		encryptedQueue,
 		parser: (i) => i,
 	});
 	const { addTransaction } = useBatch();

--- a/webapp/src/components/transaction-forms/RawTransactionForm.test.tsx
+++ b/webapp/src/components/transaction-forms/RawTransactionForm.test.tsx
@@ -14,6 +14,7 @@ const config = {
 	modules: [],
 	guard: "0xGuard",
 	singleton: "0xSingleton",
+	encryptedQueue: null,
 };
 const rpcProvider = {} as unknown as JsonRpcApiProvider;
 
@@ -44,6 +45,7 @@ describe("RawTransactionForm", () => {
 				browserProvider={browserProvider}
 				config={config}
 				rpcProvider={rpcProvider}
+				encryptedQueue={null}
 			/>,
 		);
 		expect(screen.getByLabelText(/To Address/)).toBeInTheDocument();

--- a/webapp/src/components/transaction-forms/RawTransactionForm.tsx
+++ b/webapp/src/components/transaction-forms/RawTransactionForm.tsx
@@ -34,12 +34,14 @@ export function RawTransactionForm({
 	chainId,
 	browserProvider,
 	config,
+	encryptedQueue,
 }: CommonTransactionFormProps) {
 	const { isSubmitting, error, txHash, signAndEnqueue } = useSignAndEnqueue({
 		safeAddress,
 		chainId,
 		browserProvider,
 		config,
+		encryptedQueue,
 		parser: (i) => i,
 	});
 

--- a/webapp/src/components/transaction-forms/WalletConnectTransactionForm.tsx
+++ b/webapp/src/components/transaction-forms/WalletConnectTransactionForm.tsx
@@ -98,6 +98,7 @@ export function WalletConnectTransactionForm({
 	chainId,
 	browserProvider,
 	config,
+	encryptedQueue,
 	txTo,
 	txValue,
 	txData,
@@ -116,7 +117,7 @@ export function WalletConnectTransactionForm({
 		warning,
 		isSubmitting,
 		clearResult,
-	} = useWalletConnectTransaction();
+	} = useWalletConnectTransaction({ encryptedQueue });
 
 	const formSchema = useMemo(
 		() => createWalletConnectFormSchema(config.nonce),

--- a/webapp/src/components/transaction-forms/types.ts
+++ b/webapp/src/components/transaction-forms/types.ts
@@ -14,7 +14,7 @@ interface CommonTransactionFormProps {
 	rpcProvider: JsonRpcApiProvider;
 	/** The configuration of the Safe, including the current nonce. */
 	config: SafeConfiguration;
-	/** Paramters for submitting transaction to an encrypted queue. */
+	/** Parameters for submitting transactions to an encrypted queue. */
 	encryptedQueue: EncryptedQueueParams | null;
 }
 

--- a/webapp/src/components/transaction-forms/types.ts
+++ b/webapp/src/components/transaction-forms/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserProvider, JsonRpcApiProvider } from "ethers";
+import type { EncryptedQueueParams } from "@/lib/harbour";
 import type { SafeConfiguration } from "@/lib/safe";
 import type { ChainId } from "@/lib/types";
 
@@ -13,6 +14,8 @@ interface CommonTransactionFormProps {
 	rpcProvider: JsonRpcApiProvider;
 	/** The configuration of the Safe, including the current nonce. */
 	config: SafeConfiguration;
+	/** Paramters for submitting transaction to an encrypted queue. */
+	encryptedQueue: EncryptedQueueParams | null;
 }
 
 interface ERC20TransferFormProps extends CommonTransactionFormProps {

--- a/webapp/src/hooks/useEncryptionPublicKeys.ts
+++ b/webapp/src/hooks/useEncryptionPublicKeys.ts
@@ -1,25 +1,14 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
-import { fetchEncryptionPublicKeys } from "@/lib/harbour";
+import {
+	fetchSafeOwnerEncryptionPublicKeys,
+	type SafeOwnerEncryptionPublicKeys,
+} from "@/lib/harbour";
 import type { SafeConfiguration } from "@/lib/safe";
 
 interface UseEncryptionPublicKeysProps {
 	/** Partial Safe configuration, specifically owners. */
 	safeConfig: Pick<SafeConfiguration, "owners"> | null | undefined;
 }
-
-type UseEncryptionPublicKeysResult =
-	| {
-			/** Encryption is disabled for this Harbour configuration */
-			enabled: false;
-	  }
-	| {
-			/** Encryption is enabled for this Harbour configuration */
-			enabled: true;
-			/** The registered public keys of the Safe owners */
-			publicKeys: CryptoKey[];
-			/** The owners without registered public keys */
-			missingRegistrations: string[];
-	  };
 
 /**
  * Custom React Query hook to fetch public encryption keys for the owners of the Safe.
@@ -30,7 +19,7 @@ type UseEncryptionPublicKeysResult =
 function useEncryptionPublicKeys({
 	safeConfig: maybeSafeConfig,
 }: UseEncryptionPublicKeysProps): UseQueryResult<
-	UseEncryptionPublicKeysResult,
+	SafeOwnerEncryptionPublicKeys,
 	Error
 > {
 	return useQuery({
@@ -38,20 +27,7 @@ function useEncryptionPublicKeys({
 		queryFn: async () => {
 			// biome-ignore lint/style/noNonNullAssertion: non-null assertion is safe here because of the enabled check
 			const safeConfig = maybeSafeConfig!;
-			const publicKeys = await fetchEncryptionPublicKeys({ safeConfig });
-
-			if (publicKeys === null) {
-				return { enabled: false } as const;
-			}
-
-			const missingRegistrations = safeConfig.owners.filter(
-				(owner) => !publicKeys[owner],
-			);
-			return {
-				enabled: true,
-				publicKeys: Object.values(publicKeys) as CryptoKey[],
-				missingRegistrations,
-			} as const;
+			return fetchSafeOwnerEncryptionPublicKeys({ safeConfig });
 		},
 		enabled: !!maybeSafeConfig?.owners?.length,
 		staleTime: 15 * 1000,

--- a/webapp/src/hooks/useEncryptionPublicKeys.ts
+++ b/webapp/src/hooks/useEncryptionPublicKeys.ts
@@ -1,0 +1,63 @@
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { fetchEncryptionPublicKeys } from "@/lib/harbour";
+import type { SafeConfiguration } from "@/lib/safe";
+
+interface UseEncryptionPublicKeysProps {
+	/** Partial Safe configuration, specifically owners. */
+	safeConfig: Pick<SafeConfiguration, "owners"> | null | undefined;
+}
+
+type UseEncryptionPublicKeysResult =
+	| {
+			/** Encryption is disabled for this Harbour configuration */
+			enabled: false;
+	  }
+	| {
+			/** Encryption is enabled for this Harbour configuration */
+			enabled: true;
+			/** The registered public keys of the Safe owners */
+			publicKeys: CryptoKey[];
+			/** The owners without registered public keys */
+			missingRegistrations: string[];
+	  };
+
+/**
+ * Custom React Query hook to fetch public encryption keys for the owners of the Safe.
+ *
+ * @param {UseEncryptionKeysProps} props - Parameters for fetching the encryption keys.
+ * @returns {UseQueryResult<NonceGroup[], Error>} The React Query result object containing the queue data, loading state, and error state.
+ */
+function useEncryptionPublicKeys({
+	safeConfig: maybeSafeConfig,
+}: UseEncryptionPublicKeysProps): UseQueryResult<
+	UseEncryptionPublicKeysResult,
+	Error
+> {
+	return useQuery({
+		queryKey: ["publicEncryptionKeys", maybeSafeConfig?.owners ?? []],
+		queryFn: async () => {
+			// biome-ignore lint/style/noNonNullAssertion: non-null assertion is safe here because of the enabled check
+			const safeConfig = maybeSafeConfig!;
+			const publicKeys = await fetchEncryptionPublicKeys({ safeConfig });
+
+			if (publicKeys === null) {
+				return { enabled: false } as const;
+			}
+
+			const missingRegistrations = safeConfig.owners.filter(
+				(owner) => !publicKeys[owner],
+			);
+			return {
+				enabled: true,
+				publicKeys: Object.values(publicKeys) as CryptoKey[],
+				missingRegistrations,
+			} as const;
+		},
+		enabled: !!maybeSafeConfig?.owners?.length,
+		staleTime: 15 * 1000,
+		refetchInterval: 30 * 1000,
+		throwOnError: true,
+	});
+}
+
+export { useEncryptionPublicKeys };

--- a/webapp/src/hooks/useSignAndEnqueue.test.ts
+++ b/webapp/src/hooks/useSignAndEnqueue.test.ts
@@ -44,6 +44,7 @@ describe("useSignAndEnqueue", () => {
 				browserProvider,
 				config,
 				parser,
+				encryptedQueue: null,
 			}),
 		);
 		await act(async () => {
@@ -71,6 +72,7 @@ describe("useSignAndEnqueue", () => {
 				browserProvider,
 				config,
 				parser,
+				encryptedQueue: null,
 			}),
 		);
 		await act(async () => {
@@ -100,6 +102,7 @@ describe("useSignAndEnqueue", () => {
 				config,
 				parser,
 				onEnqueued,
+				encryptedQueue: null,
 			}),
 		);
 		await act(async () => {

--- a/webapp/src/hooks/useSignAndEnqueue.ts
+++ b/webapp/src/hooks/useSignAndEnqueue.ts
@@ -2,7 +2,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { type BrowserProvider, ethers } from "ethers";
 import { useCallback, useState } from "react";
 import { useWaku } from "@/contexts/WakuContext";
-import { signAndEnqueueSafeTransaction } from "@/lib/harbour";
+import {
+	type EncryptedQueueParams,
+	signAndEnqueueSafeTransaction,
+} from "@/lib/harbour";
 import { getSafeTransaction, type SafeConfiguration } from "@/lib/safe";
 import type { ChainId, SafeTransaction } from "@/lib/types";
 
@@ -15,6 +18,9 @@ interface SignAndEnqueueProps<T> {
 	browserProvider: BrowserProvider;
 	/** The configuration of the Safe, including the current nonce. */
 	config: SafeConfiguration;
+	/** The encrypted queue paramters. */
+	encryptedQueue: EncryptedQueueParams | null;
+
 	parser: (input: T) => SafeTransactionInput;
 	onEnqueued?: () => void;
 }
@@ -36,6 +42,7 @@ export function useSignAndEnqueue<T = SafeTransactionInput>({
 	chainId,
 	browserProvider,
 	config,
+	encryptedQueue,
 	parser,
 	onEnqueued,
 }: SignAndEnqueueProps<T>): SignAndEnqueueReturn<T> {
@@ -71,6 +78,7 @@ export function useSignAndEnqueue<T = SafeTransactionInput>({
 					browserProvider,
 					transaction,
 					waku,
+					encryptedQueue,
 				);
 
 				onEnqueued?.();
@@ -94,6 +102,7 @@ export function useSignAndEnqueue<T = SafeTransactionInput>({
 			chainId,
 			browserProvider,
 			config,
+			encryptedQueue,
 		],
 	);
 	return {

--- a/webapp/src/hooks/useWalletConnectTransaction.test.ts
+++ b/webapp/src/hooks/useWalletConnectTransaction.test.ts
@@ -21,6 +21,9 @@ const params = {
 	topic: "topic",
 	reqId: "42",
 };
+const props = {
+	encryptedQueue: null,
+};
 
 vi.mock("@/contexts/WakuContext", () => ({ useWaku: () => ({}) }));
 vi.mock("@/hooks/walletConnect", () => ({
@@ -59,7 +62,7 @@ describe("useWalletConnectTransaction", () => {
 		const { useWalletConnectTransaction } = await import(
 			"./useWalletConnectTransaction"
 		);
-		const { result } = renderHook(() => useWalletConnectTransaction());
+		const { result } = renderHook(() => useWalletConnectTransaction(props));
 		await act(async () => {
 			await result.current.submitTransaction(params);
 		});
@@ -80,7 +83,7 @@ describe("useWalletConnectTransaction", () => {
 		const { useWalletConnectTransaction } = await import(
 			"./useWalletConnectTransaction"
 		);
-		const { result } = renderHook(() => useWalletConnectTransaction());
+		const { result } = renderHook(() => useWalletConnectTransaction(props));
 		await act(async () => {
 			await result.current.submitTransaction(params);
 		});
@@ -110,7 +113,7 @@ describe("useWalletConnectTransaction", () => {
 		const { useWalletConnectTransaction } = await import(
 			"./useWalletConnectTransaction"
 		);
-		const { result } = renderHook(() => useWalletConnectTransaction());
+		const { result } = renderHook(() => useWalletConnectTransaction(props));
 		await act(async () => {
 			await result.current.submitTransaction(params);
 		});
@@ -132,7 +135,7 @@ describe("useWalletConnectTransaction", () => {
 		const { useWalletConnectTransaction } = await import(
 			"./useWalletConnectTransaction"
 		);
-		const { result } = renderHook(() => useWalletConnectTransaction());
+		const { result } = renderHook(() => useWalletConnectTransaction(props));
 		await act(async () => {
 			await result.current.submitTransaction(params);
 			result.current.clearResult();

--- a/webapp/src/hooks/useWalletConnectTransaction.ts
+++ b/webapp/src/hooks/useWalletConnectTransaction.ts
@@ -3,8 +3,15 @@ import { ethers } from "ethers";
 import { useCallback, useState } from "react";
 import { useWaku } from "@/contexts/WakuContext";
 import { useWalletConnect } from "@/hooks/walletConnect";
-import { signAndEnqueueSafeTransaction } from "@/lib/harbour";
+import {
+	type EncryptedQueueParams,
+	signAndEnqueueSafeTransaction,
+} from "@/lib/harbour";
 import { getSafeTransaction } from "@/lib/safe";
+
+type UseWalletConnectTransactionParams = {
+	encryptedQueue: EncryptedQueueParams | null;
+};
 
 type WalletConnectTransactionParams = {
 	safeAddress: string;
@@ -32,7 +39,9 @@ type WalletConnectTransactionResult = {
  *
  * @returns Object containing transaction result state and submission functions
  */
-export function useWalletConnectTransaction() {
+export function useWalletConnectTransaction({
+	encryptedQueue,
+}: UseWalletConnectTransactionParams) {
 	const waku = useWaku();
 	const { walletkit } = useWalletConnect();
 	const [result, setResult] = useState<WalletConnectTransactionResult>({
@@ -76,6 +85,7 @@ export function useWalletConnectTransaction() {
 					browserProvider,
 					transaction,
 					waku,
+					encryptedQueue,
 				);
 
 				// 2. Attempt to respond to WalletConnect session (separate from transaction success)
@@ -146,7 +156,7 @@ export function useWalletConnectTransaction() {
 				});
 			}
 		},
-		[walletkit, waku],
+		[walletkit, waku, encryptedQueue],
 	);
 
 	/**

--- a/webapp/src/lib/harbour.test.ts
+++ b/webapp/src/lib/harbour.test.ts
@@ -260,7 +260,12 @@ describe("harbour", () => {
 				getSigner: vi.fn().mockResolvedValue({}),
 			} as unknown as JsonRpcApiProvider;
 
-			const res = await signAndEnqueueSafeTransaction(walletProvider, tx, waku);
+			const res = await signAndEnqueueSafeTransaction(
+				walletProvider,
+				tx,
+				waku,
+				null,
+			);
 
 			expect(switchToChain).toHaveBeenCalledWith(walletProvider, tx.chainId);
 			expect(waku.send).toHaveBeenCalledTimes(1);
@@ -296,6 +301,7 @@ describe("harbour", () => {
 				walletProvider,
 				tx,
 				waku as WakuManager,
+				null,
 			);
 
 			// Switch to chain of Safe to sign

--- a/webapp/src/lib/harbour.ts
+++ b/webapp/src/lib/harbour.ts
@@ -510,7 +510,7 @@ async function signAndEnqueueSafeTransaction(
 }
 
 /**
- * Encrypt and enqueue a Safe trnasction to Secret Harbour.
+ * Encrypt and enqueue a Safe transaction to Secret Harbour.
  */
 async function encryptAndEnqueueSafeTransaction(
 	secretHarbour: Contract,

--- a/webapp/src/lib/safe.ts
+++ b/webapp/src/lib/safe.ts
@@ -6,6 +6,7 @@ import type {
 	FullSafeTransaction,
 	HarbourSignature,
 	HarbourTransactionDetails,
+	SafeTransactionWithNonce,
 } from "./types";
 
 /**
@@ -229,11 +230,9 @@ async function signSafeTransaction(
 
 	return signer.signTypedData(domain, SAFE_TX_TYPE, message);
 }
+
 /**
- * Signs a Safe transaction using EIP-712 typed data
- * @param signer - The ethers.js signer
- * @param transaction - The transaction request parameters
- * @returns The signature string
+ * Computes an EIP-712 Safe transaction hash
  */
 function getSafeTransactionHash(transaction: FullSafeTransaction): string {
 	const domain = {
@@ -255,6 +254,19 @@ function getSafeTransactionHash(transaction: FullSafeTransaction): string {
 	};
 
 	return ethers.TypedDataEncoder.hash(domain, SAFE_TX_TYPE, message);
+}
+
+/**
+ * Computes an EIP-712 struct hash of the Safe transaction data.
+ */
+function getSafeTransactionStructHash(
+	transaction: SafeTransactionWithNonce,
+): string {
+	return ethers.TypedDataEncoder.hashStruct(
+		"SafeTx",
+		SAFE_TX_TYPE,
+		transaction,
+	);
 }
 
 /**
@@ -298,6 +310,7 @@ export {
 	signSafeTransaction,
 	getSafeTransaction,
 	getSafeTransactionHash,
+	getSafeTransactionStructHash,
 };
 
 export type { SafeConfiguration };

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -64,11 +64,18 @@ interface HarbourTransactionDetails extends SafeTransaction {
 }
 
 /**
- * Interface representing a complete Safe transaction, including nonce, chainId, and Safe address.
+ * Interface extending SafeTransaction a nonce. This is the transaction
+ * parameters that are signed as part of the EIP-712 message.
  */
-interface FullSafeTransaction extends SafeTransaction {
+interface SafeTransactionWithNonce extends SafeTransaction {
 	/** The nonce of the Safe transaction. */
 	nonce: string;
+}
+
+/**
+ * Interface representing a complete Safe transaction, including nonce, chainId, and Safe address.
+ */
+interface FullSafeTransaction extends SafeTransactionWithNonce {
 	/** The chain ID where the transaction is intended to be executed. */
 	chainId: ChainId;
 	/** The address of the Safe contract. */
@@ -82,5 +89,6 @@ export type {
 	HarbourTransactionDetails,
 	MetaTransaction,
 	FullSafeTransaction,
+	SafeTransactionWithNonce,
 	SafeTransaction,
 };

--- a/webapp/src/routes/enqueue.tsx
+++ b/webapp/src/routes/enqueue.tsx
@@ -248,7 +248,7 @@ function EnqueueContent(props: EnqueueContentProps) {
 								>
 									<span className="text-lg w-4 h-4 me-3">{"⚠"}</span>
 									<div>
-										One ore more Safe owners have not registered their
+										One or more Safe owners have not registered their
 										encryption key. The following owners will not be able to see
 										enqueued Safe transactions:
 										<ul className="list-disc ml-4">

--- a/webapp/src/routes/enqueue.tsx
+++ b/webapp/src/routes/enqueue.tsx
@@ -248,9 +248,9 @@ function EnqueueContent(props: EnqueueContentProps) {
 								>
 									<span className="text-lg w-4 h-4 me-3">{"⚠"}</span>
 									<div>
-										One or more Safe owners have not registered their
-										encryption key. The following owners will not be able to see
-										enqueued Safe transactions:
+										One or more Safe owners have not registered their encryption
+										key. The following owners will not be able to see enqueued
+										Safe transactions:
 										<ul className="list-disc ml-4">
 											{encryptionPublicKeys.missingRegistrations.map(
 												(owner) => (

--- a/webapp/src/routes/enqueue.tsx
+++ b/webapp/src/routes/enqueue.tsx
@@ -218,7 +218,7 @@ function EnqueueContent(props: EnqueueContentProps) {
 				{encryptionPublicKeysError && (
 					<div className="bg-red-50 border-l-4 border-red-400 p-4 mb-6">
 						<p className="text-red-700">
-							Error loading Safe configuration:{" "}
+							Error loading Safe owner encryption keys:{" "}
 							{encryptionPublicKeysError.message}
 						</p>
 					</div>

--- a/webapp/src/routes/queue.tsx
+++ b/webapp/src/routes/queue.tsx
@@ -3,26 +3,26 @@ import { zodValidator } from "@tanstack/zod-adapter";
 import type { BrowserProvider, JsonRpcApiProvider } from "ethers";
 import { PlusCircle } from "lucide-react";
 import { useState } from "react";
+import { ActionCard } from "@/components/ActionCard";
+import { BackToDashboardButton } from "@/components/BackButton";
+import { QueueTransactionItem } from "@/components/QueueTransactionItem";
+import { RequireWallet, useWalletProvider } from "@/components/RequireWallet";
+import { useSession } from "@/contexts/SessionContext";
 import { useWaku } from "@/contexts/WakuContext";
-import type { ChainId } from "@/lib/types";
-import { ActionCard } from "../components/ActionCard";
-import { BackToDashboardButton } from "../components/BackButton";
-import { QueueTransactionItem } from "../components/QueueTransactionItem";
-import { RequireWallet, useWalletProvider } from "../components/RequireWallet";
 import {
 	type TransactionToExecute,
 	useExecuteTransaction,
-} from "../hooks/useExecuteTransaction";
+} from "@/hooks/useExecuteTransaction";
 import {
 	useChainlistRpcProvider,
 	useHarbourRpcProvider,
-} from "../hooks/useRpcProvider";
-import { useSafeConfiguration } from "../hooks/useSafeConfiguration";
-import { useSafeQueue } from "../hooks/useSafeQueue";
-import { type NonceGroup, signAndEnqueueSafeTransaction } from "../lib/harbour";
-import type { SafeConfiguration } from "../lib/safe";
-import type { FullSafeTransaction } from "../lib/types";
-import { safeIdSchema } from "../lib/validators";
+} from "@/hooks/useRpcProvider";
+import { useSafeConfiguration } from "@/hooks/useSafeConfiguration";
+import { useSafeQueue } from "@/hooks/useSafeQueue";
+import { type NonceGroup, signAndEnqueueSafeTransaction } from "@/lib/harbour";
+import type { SafeConfiguration } from "@/lib/safe";
+import type { ChainId, FullSafeTransaction } from "@/lib/types";
+import { safeIdSchema } from "@/lib/validators";
 
 // Define the route before the component so Route is in scope
 /**
@@ -63,6 +63,7 @@ function QueueContent({
 	chainId,
 }: QueueContentProps) {
 	const waku = useWaku();
+	const { keys: sessionKeys } = useSession();
 	const {
 		data: queue,
 		isLoading: isLoadingQueue,
@@ -128,7 +129,15 @@ function QueueContent({
 				safeAddress,
 				chainId,
 			};
-			await signAndEnqueueSafeTransaction(walletProvider, fullTx, waku);
+			const encryptedQueue = sessionKeys
+				? ({ operation: "sign-only", sessionKeys } as const)
+				: null;
+			await signAndEnqueueSafeTransaction(
+				walletProvider,
+				fullTx,
+				waku,
+				encryptedQueue,
+			);
 			setSignSuccessTxHash(txWithSigs.safeTxHash);
 		} catch (err) {
 			const errMsg =
@@ -162,6 +171,7 @@ function QueueContent({
 					<BackToDashboardButton safeAddress={safeAddress} chainId={chainId} />
 					<h1 className="text-3xl font-bold text-gray-900 mt-4">
 						Transaction Queue
+						{!!sessionKeys && " 🔐"}
 					</h1>
 					<p className="text-gray-700 mt-2">
 						Safe:{" "}


### PR DESCRIPTION
This PR adds support for enqueuing encrypted Safe transactions to Secret Harbour. Additionally, it warns the user in the case where not all owners of the Safe have registered encryption keys.

The queue does not display any transactions at the moment, that is in the next PR.

