### PR TITLE
[Web App] Use Hash Based Routing

### DIFF
--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,4 +1,8 @@
-import { createRouter, RouterProvider } from "@tanstack/react-router";
+import {
+	createHashHistory,
+	createRouter,
+	RouterProvider,
+} from "@tanstack/react-router";
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
@@ -16,10 +20,17 @@ import { WakuProvider } from "./contexts/WakuContext.tsx";
 import reportWebVitals from "./reportWebVitals.ts";
 
 /**
+ * TanStack history provider configured to use hashing instead of paths.
+ * This is to support hosting environments that do not have index.html rewriting.
+ */
+const history = createHashHistory();
+
+/**
  * TanStack Router instance configured with the generated route tree and TanStack Query context.
  */
 const router = createRouter({
 	routeTree,
+	history,
 	basepath: __BASE_PATH__,
 	context: {
 		...TanstackQuery.getContext(),


### PR DESCRIPTION
This PR changes the history provider to use URI fragments (i.e. `#...`) for router history. For example, this means that the settings page will now be `harbour.safe.dev/#/settings`. From the [docs](https://tanstack.com/router/latest/docs/framework/react/guide/history-types#hash-routing):

> Hash routing can be helpful if your server doesn't support rewrites to index.html for HTTP requests (among other environments that don't have a server).

This is an alternative to #98. The upside being that this is a simple and supported solution to the problem, however, it does mean that we use URL fragments for navigation and have pages at different URLs than before.
